### PR TITLE
Prevent rendering a non-scrollable table when dataset length is 0

### DIFF
--- a/src/Table/Table.js
+++ b/src/Table/Table.js
@@ -327,7 +327,13 @@ export default class Table extends React.Component {
 
     let style = {};
 
-    if (scrollContainer != null) {
+    if (data.length === 0) {
+      innerContent = (
+        <tbody>
+          {this.getEmptyRowCell(columns)}
+        </tbody>
+      );
+    } else if (scrollContainer != null) {
       style.height = containerHeight;
       let visibleItems = Math.ceil(containerHeight / itemHeight);
 
@@ -377,9 +383,7 @@ export default class Table extends React.Component {
 
     // Use scroll table on first render to check if we need to scroll
     // and if content is bigger than its container
-    if (data.length &&
-      (props.useFlex || itemHeight === 0 || itemListHeight > containerHeight)
-      ) {
+    if (props.useFlex || itemHeight === 0 || itemListHeight > containerHeight) {
       tableContent =
         this.getScrollTable(
           columns, data, sortBy, itemHeight, containerHeight, idAttribute


### PR DESCRIPTION
This fixes a bug revealed in the groups table in DCOS UI.