### PR TITLE
Allow dropdown to appear above dropdown button if viewport is too small

### DIFF
--- a/src/Dropdown/Dropdown.js
+++ b/src/Dropdown/Dropdown.js
@@ -31,14 +31,13 @@ export default class Dropdown extends Util.mixin(BindMixin) {
     // it's rendered. It's rendered inside a concealed container, so it's okay
     // if it renders in the wrong direction.
     if (this.state.menuHeight == null) {
-      console.log('calculate menu height');
       let dropdownMenuConcealer = this.refs.dropdownMenuConcealer.getDOMNode();
       let menuDirection = this.state.menuDirection;
       let menuHeight = this.state.menuHeight;
 
       if (dropdownMenuConcealer != null) {
         // Get the height and direction of the concealed menu.
-        menuHeight = dropdownMenuConcealer.firstChild.clientHeight;
+        menuHeight = dropdownMenuConcealer.firstChild.clientHeight || 0;
         menuDirection = this.getMenuDirection(menuHeight);
       }
 
@@ -48,8 +47,6 @@ export default class Dropdown extends Util.mixin(BindMixin) {
         menuDirection,
         menuHeight
       });
-    } else {
-      console.log('do not calculate menu height');
     }
   }
 
@@ -170,7 +167,7 @@ export default class Dropdown extends Util.mixin(BindMixin) {
     // the DOM element around while we are measuring it.
     let props = this.props;
     let state = this.state;
-    let dropdownKey = state.menuHeight || 'initial-render';
+    let dropdownKey = 'initial-render';
     let dropdownMenu = null;
     let dropdownMenuClassSet = classNames(
       state.menuDirection,
@@ -187,6 +184,10 @@ export default class Dropdown extends Util.mixin(BindMixin) {
       dropdownStateClassSet,
       props.wrapperClassName
     );
+
+    if (state.menuHeight != null) {
+      dropdownKey = state.menuHeight;
+    }
 
     if (state.isOpen) {
       dropdownMenu = (

--- a/src/Dropdown/Dropdown.js
+++ b/src/Dropdown/Dropdown.js
@@ -39,7 +39,6 @@ export default class Dropdown extends Util.mixin(BindMixin) {
       );
       // Get the height of the concealed menu.
       menuHeight = dropdownMenuConcealer.children[0].clientHeight;
-      // Get the
       menuDirection = this.getMenuDirection(menuHeight);
 
       // Only set state if the properties actually changed.

--- a/src/Dropdown/Dropdown.js
+++ b/src/Dropdown/Dropdown.js
@@ -169,30 +169,32 @@ export default class Dropdown extends Util.mixin(BindMixin) {
   render() {
     // Set a key based on the menu height so that React knows to keep the
     // the DOM element around while we are measuring it.
-    let dropdownKey = this.state.knowMenuHeight || 'initial-render';
+    let props = this.props;
+    let state = this.state;
+    let dropdownKey = state.knowMenuHeight || 'initial-render';
     let dropdownMenu = null;
     let dropdownMenuClassSet = classNames(
-      this.state.menuDirection,
-      this.props.dropdownMenuClassName
+      state.menuDirection,
+      props.dropdownMenuClassName
     );
     let dropdownStateClassSet = {
-      'open': this.state.isOpen
+      'open': state.isOpen
     };
-    let items = this.props.items;
+    let items = props.items;
     let transitionName =
-      `${this.props.transitionName}-${this.state.menuDirection}`;
+      `${props.transitionName}-${state.menuDirection}`;
     let wrapperClassSet = classNames(
-      this.state.menuDirection,
+      state.menuDirection,
       dropdownStateClassSet,
-      this.props.wrapperClassName
+      props.wrapperClassName
     );
 
-    if (this.state.isOpen) {
+    if (state.isOpen) {
       dropdownMenu = (
         <span className={dropdownMenuClassSet}
           role="menu" ref="dropdownMenu" key={dropdownKey}>
-          <ul className={this.props.dropdownMenuListClassName}>
-            {this.getMenuItems(this.props.items)}
+          <ul className={props.dropdownMenuListClassName}>
+            {this.getMenuItems(props.items)}
           </ul>
         </span>
       );
@@ -200,8 +202,8 @@ export default class Dropdown extends Util.mixin(BindMixin) {
 
     // If we don't know the menu's height, we render it invisibly and then
     // immediately measure its height in #componentDidUpdate, which will change
-    // the sate and trigger another render.
-    if (this.state.isOpen && this.state.knowMenuHeight === false) {
+    // the state and trigger another render.
+    if (state.isOpen && state.knowMenuHeight === false) {
       dropdownMenu = (
         <div className="dropdown-menu-concealer" ref="dropdownMenuConcealer">
           {dropdownMenu}
@@ -209,7 +211,7 @@ export default class Dropdown extends Util.mixin(BindMixin) {
       );
     }
 
-    if (this.props.transition) {
+    if (props.transition) {
       dropdownMenu = (
         <CSSTransitionGroup transitionName={transitionName}>
           {dropdownMenu}
@@ -222,11 +224,11 @@ export default class Dropdown extends Util.mixin(BindMixin) {
         tabIndex="1"
         onBlur={this.handleWrapperBlur}
         ref="dropdownWrapper">
-        <button className={this.props.buttonClassName}
+        <button className={props.buttonClassName}
           onClick={this.handleMenuToggle}
           ref="button"
           type="button">
-          {this.getSelectedHtml(this.state.selectedID, items)}
+          {this.getSelectedHtml(state.selectedID, items)}
         </button>
         {dropdownMenu}
       </span>

--- a/src/Dropdown/Dropdown.js
+++ b/src/Dropdown/Dropdown.js
@@ -66,9 +66,9 @@ export default class Dropdown extends Util.mixin(BindMixin) {
       return 'down';
     }
     // Calculate the space above and below the dropdown button.
-    let spaceAroundDropdown = this.getSpaceAroundDropdown();
+    let spaceBelowDropdown = this.getSpaceBelowDropdown();
 
-    if (menuHeight > spaceAroundDropdown.bottom) {
+    if (menuHeight > spaceBelowDropdown) {
       return 'up';
     } else {
       return 'down';
@@ -108,18 +108,14 @@ export default class Dropdown extends Util.mixin(BindMixin) {
     return obj.selectedHtml || obj.html;
   }
 
-  getSpaceAroundDropdown() {
+  getSpaceBelowDropdown() {
     let dropdownWrapper = React.findDOMNode(this.refs.dropdownWrapper);
     let position = dropdownWrapper.getBoundingClientRect();
     let viewportHeight = global.window.innerHeight;
 
-    // Calculate the distance from the top of the viewport to the top of the
-    // dropdown button as well as the distance from the bottom of the viewport
-    // to the bottom of the dropdown button.
-    return {
-      top: position.top,
-      bottom: viewportHeight - position.bottom
-    };
+    // Calculate the distance from the bottom of the viewport to the bottom of
+    // the dropdown button.
+    return viewportHeight - position.bottom;
   }
 
   handleExternalClick() {

--- a/src/Dropdown/Dropdown.js
+++ b/src/Dropdown/Dropdown.js
@@ -31,6 +31,7 @@ export default class Dropdown extends Util.mixin(BindMixin) {
     // it's rendered. It's rendered inside a concealed container, so it's okay
     // if it renders in the wrong direction.
     if (this.state.menuHeight == null) {
+      console.log('calculate menu height');
       let dropdownMenuConcealer = this.refs.dropdownMenuConcealer.getDOMNode();
       let menuDirection = this.state.menuDirection;
       let menuHeight = this.state.menuHeight;
@@ -47,6 +48,8 @@ export default class Dropdown extends Util.mixin(BindMixin) {
         menuDirection,
         menuHeight
       });
+    } else {
+      console.log('do not calculate menu height');
     }
   }
 

--- a/src/Dropdown/Dropdown.js
+++ b/src/Dropdown/Dropdown.js
@@ -32,15 +32,13 @@ export default class Dropdown extends Util.mixin(BindMixin) {
     // it's rendered. It's rendered inside a concealed container, so it's okay
     // if it renders in the wrong direction.
     if (!this.state.knowMenuHeight) {
-      let dropdownMenuConcealer = React.findDOMNode(
-        this.refs.dropdownMenuConcealer
-      );
+      let dropdownMenuConcealer = this.refs.dropdownMenuConcealer.getDOMNode();
       let menuDirection = this.state.menuDirection;
       let menuHeight = this.state.menuHeight;
 
       if (dropdownMenuConcealer != null) {
         // Get the height and direction of the concealed menu.
-        menuHeight = dropdownMenuConcealer.children[0].clientHeight;
+        menuHeight = dropdownMenuConcealer.firstChild.clientHeight;
         menuDirection = this.getMenuDirection(menuHeight);
       }
 

--- a/src/Dropdown/Dropdown.js
+++ b/src/Dropdown/Dropdown.js
@@ -37,8 +37,12 @@ export default class Dropdown extends Util.mixin(BindMixin) {
       let dropdownMenuConcealer = React.findDOMNode(
         this.refs.dropdownMenuConcealer
       );
-      // Get the height of the concealed menu.
-      menuHeight = dropdownMenuConcealer.children[0].clientHeight;
+
+      if (dropdownMenuConcealer != null) {
+        // Get the height of the concealed menu.
+        menuHeight = dropdownMenuConcealer.children[0].clientHeight;
+      }
+
       menuDirection = this.getMenuDirection(menuHeight);
 
       // Only set state if the properties actually changed.

--- a/src/Dropdown/Dropdown.js
+++ b/src/Dropdown/Dropdown.js
@@ -22,8 +22,7 @@ export default class Dropdown extends Util.mixin(BindMixin) {
       menuDirection: 'down',
       menuHeight: null,
       isOpen: false,
-      selectedID: null,
-      knowMenuHeight: false
+      selectedID: null
     };
   }
 
@@ -31,7 +30,7 @@ export default class Dropdown extends Util.mixin(BindMixin) {
     // If we don't know the menu height already, we need to calculate it after
     // it's rendered. It's rendered inside a concealed container, so it's okay
     // if it renders in the wrong direction.
-    if (!this.state.knowMenuHeight) {
+    if (this.state.menuHeight == null) {
       let dropdownMenuConcealer = this.refs.dropdownMenuConcealer.getDOMNode();
       let menuDirection = this.state.menuDirection;
       let menuHeight = this.state.menuHeight;
@@ -42,10 +41,9 @@ export default class Dropdown extends Util.mixin(BindMixin) {
         menuDirection = this.getMenuDirection(menuHeight);
       }
 
-      // Setting state with knownHeight: true will re-render the dropdown in
-      // the correct direction and not concealed.
+      // Setting state with menu height and direction will re-render the
+      // dropdown in the correct direction and not concealed.
       this.setState({
-        knowMenuHeight: true,
         menuDirection,
         menuHeight
       });
@@ -169,7 +167,7 @@ export default class Dropdown extends Util.mixin(BindMixin) {
     // the DOM element around while we are measuring it.
     let props = this.props;
     let state = this.state;
-    let dropdownKey = state.knowMenuHeight || 'initial-render';
+    let dropdownKey = state.menuHeight || 'initial-render';
     let dropdownMenu = null;
     let dropdownMenuClassSet = classNames(
       state.menuDirection,
@@ -201,7 +199,7 @@ export default class Dropdown extends Util.mixin(BindMixin) {
     // If we don't know the menu's height, we render it invisibly and then
     // immediately measure its height in #componentDidUpdate, which will change
     // the state and trigger another render.
-    if (state.isOpen && state.knowMenuHeight === false) {
+    if (state.isOpen && state.menuHeight == null) {
       dropdownMenu = (
         <div className="dropdown-menu-concealer" ref="dropdownMenuConcealer">
           {dropdownMenu}

--- a/src/Dropdown/Dropdown.js
+++ b/src/Dropdown/Dropdown.js
@@ -171,9 +171,9 @@ export default class Dropdown extends Util.mixin(BindMixin) {
   }
 
   render() {
-    // Set a key based on the menu direction so that React knows to keep the
-    // the menu around while we are measuring it.
-    let dropdownKey = this.state.knowMenuHeight || "initial-render";
+    // Set a key based on the menu height so that React knows to keep the
+    // the DOM element around while we are measuring it.
+    let dropdownKey = this.state.knowMenuHeight || 'initial-render';
     let dropdownMenu = null;
     let dropdownMenuClassSet = classNames(
       this.state.menuDirection,

--- a/src/Dropdown/Dropdown.js
+++ b/src/Dropdown/Dropdown.js
@@ -19,7 +19,7 @@ export default class Dropdown extends Util.mixin(BindMixin) {
   constructor() {
     super();
     this.state = {
-      menuDirection: "down",
+      menuDirection: 'down',
       menuHeight: null,
       isOpen: false,
       selectedID: null,
@@ -71,15 +71,15 @@ export default class Dropdown extends Util.mixin(BindMixin) {
   getMenuDirection(menuHeight) {
     // If we don't know the menu height, then render the menu down to start.
     if (menuHeight == null) {
-      return "down";
+      return 'down';
     }
     // Calculate the space above and below the dropdown button.
     let spaceAroundDropdown = this.getSpaceAroundDropdown();
 
     if (menuHeight > spaceAroundDropdown.bottom) {
-      return "up";
+      return 'up';
     } else {
-      return "down";
+      return 'down';
     }
   }
 
@@ -206,8 +206,7 @@ export default class Dropdown extends Util.mixin(BindMixin) {
     // will change the sate and trigger another render.
     if (this.state.isOpen && this.state.knowMenuPosition === false) {
       dropdownMenu = (
-        <div className="dropdown-menu-concealer" ref="dropdownMenuConcealer"
-          style={{"visibility": "hidden", "opacity": 0}}>
+        <div className="dropdown-menu-concealer" ref="dropdownMenuConcealer">
           {dropdownMenu}
         </div>
       );

--- a/src/Dropdown/__tests__/Dropdown-test.js
+++ b/src/Dropdown/__tests__/Dropdown-test.js
@@ -19,7 +19,7 @@ describe('Dropdown', function () {
         items={MockDropdownList}
         onItemSelection={this.callback}
         selectedID="bar"
-        transition={true}
+        transition={false}
         wrapperClassName="dropdown" />
     );
   });

--- a/src/Dropdown/__tests__/Dropdown-test.js
+++ b/src/Dropdown/__tests__/Dropdown-test.js
@@ -1,9 +1,11 @@
-var React = require('react/addons');
-var TestUtils = React.addons.TestUtils;
-
+jest.dontMock('../../Mixin/BindMixin');
 jest.dontMock('../../Util/Util');
+jest.dontMock('../../Util/DOMUtil');
 jest.dontMock('../Dropdown');
 jest.dontMock('./fixtures/MockDropdownList');
+
+var React = require('react/addons');
+var TestUtils = React.addons.TestUtils;
 
 var MockDropdownList = require('./fixtures/MockDropdownList');
 var Dropdown = require('../Dropdown.js');

--- a/src/Dropdown/dropdown.less
+++ b/src/Dropdown/dropdown.less
@@ -113,7 +113,7 @@
 
 .dropdown-menu-concealer {
   opacity: 0;
-  visibility: none !important;
+  visibility: hidden;
 }
 
 .dropdown-menu-down-enter {

--- a/src/Dropdown/dropdown.less
+++ b/src/Dropdown/dropdown.less
@@ -1,4 +1,4 @@
-@keyframes dropdown-slide-down {
+@keyframes dropdown-down-enter {
   0% {
     transform: translateY(-30px);
   }
@@ -7,12 +7,30 @@
   }
 }
 
-@keyframes dropdown-slide-up {
+@keyframes dropdown-down-leave {
   0% {
     transform: translateY(0);
   }
   100% {
     transform: translateY(-30px);
+  }
+}
+
+@keyframes dropdown-up-enter {
+  0% {
+    transform: translateY(30px);
+  }
+  100% {
+    transform: translateY(0);
+  }
+}
+
+@keyframes dropdown-up-leave {
+  0% {
+    transform: translateY(0);
+  }
+  100% {
+    transform: translateY(30px);
   }
 }
 
@@ -68,8 +86,21 @@
 .dropdown-menu {
   // This can be removed when Canvas is updated to toggle visibility: visible
   display: block !important;
-  transform-origin: top center;
   z-index: 1;
+
+  &.up {
+    bottom: 100%;
+    margin-bottom: 5px;
+    top: auto;
+    transform-origin: bottom center;
+  }
+
+  &.down {
+    bottom: auto;
+    margin-top: 5px;
+    top: 100%;
+    transform-origin: top center;
+  }
 
   em {
     font-style: italic;
@@ -80,12 +111,26 @@
   }
 }
 
-.dropdown-menu-enter {
-  animation: dropdown-fade-in 0.25s, dropdown-slide-down 0.25s;
+.dropdown-menu-concealer {
+  opacity: 0;
+  visibility: none !important;
 }
 
-.dropdown-menu-leave {
-  animation: dropdown-fade-out 0.25s, dropdown-slide-up 0.25s;
+.dropdown-menu-down-enter {
+  animation: dropdown-fade-in 0.25s, dropdown-down-enter 0.25s;
+}
+
+.dropdown-menu-down-leave {
+  animation: dropdown-fade-out 0.25s, dropdown-down-leave 0.25s;
+  z-index: 3;
+}
+
+.dropdown-menu-up-enter {
+  animation: dropdown-fade-in 0.25s, dropdown-up-enter 0.25s;
+}
+
+.dropdown-menu-up-leave {
+  animation: dropdown-fade-out 0.25s, dropdown-up-leave 0.25s;
   z-index: 3;
 }
 

--- a/src/VirtualList/__tests__/VirtualList-test.js
+++ b/src/VirtualList/__tests__/VirtualList-test.js
@@ -3,13 +3,6 @@ var VirtualList = require('../VirtualList');
 jest.dontMock('../VirtualList');
 jest.dontMock('../../Util/Util');
 
-var mathFloor = Math.floor;
-var mathRandom = Math.random;
-
-function random(min, max) {
-  return mathFloor((mathRandom() * max) + min);
-}
-
 describe('VirtualList', function () {
 
   describe('#getBox box that defines the visible part of the list', function () {


### PR DESCRIPTION
Reading the component's code might be a little confusing, so here's an overview of what happens:
1. The first time the dropdown opens, it renders inside a hidden element with class `dropdown-menu-concealer`
2. Immediately afterwards, `componentDidUpdate` measures the concealed menu, as well as the dropdown button's position in the viewport, and the viewport height, and updates the state with the correct position for the menu (`up` or `down`)
3. The component renders again with the correct `up` or `down` classes & animations, and without the concealer
4. Every subsequent time the dropdown opens, it calculates the direction at the same time it toggles its `open` state.