### PR TITLE
fix outdated eslint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -39,7 +39,7 @@
     "space-before-function-paren": [2, {
       "anonymous": "always", "named": "never"
     }],
-    "spaced-line-comment": [2, "always"],
+    "spaced-comment": [2, "always"],
     // "max-len": [2, 80, 4], TODO: DCOS-914
     "valid-jsdoc": [2, {
       "requireReturn": false,


### PR DESCRIPTION
Are you guys interested in more strict `.eslintrc`? I could work on it.
