### PR TITLE
Do not cap height of Table

### DIFF
--- a/src/Table/Table.js
+++ b/src/Table/Table.js
@@ -1,6 +1,5 @@
 import classNames from 'classnames';
 import DOMUtil from '../Util/DOMUtil';
-import GeminiScrollbar from 'react-gemini-scrollbar';
 import React, {PropTypes} from 'react/addons';
 import Util from '../Util/Util';
 import VirtualList from '../VirtualList/VirtualList';
@@ -83,14 +82,6 @@ export default class Table extends React.Component {
     let state = this.state;
     let refs = this.refs;
 
-    if (state.scrollContainer == null && refs.gemini != null) {
-      // Get the Gemini scroll view as the container view.
-      // We need this since both Gemini and VirtualList need the same element
-      newState.scrollContainer = React.findDOMNode(
-        refs.gemini.refs['scroll-view']
-      );
-    }
-
     if (props.itemHeight == null &&
       state.itemHeight == null &&
       refs.itemHeightContainer != null) {
@@ -123,27 +114,10 @@ export default class Table extends React.Component {
       newState.viewportHeight =
         props.windowRatio * DOMUtil.getViewportHeight() - headerHeight;
       // Calculated scroll container height
-      let scrollContainerHeight =
-        DOMUtil.getComputedDimensions(React.findDOMNode(refs.container)).height -
-        headerHeight;
-
-      // Gemini may not always be present
-      if (newState.scrollContainer) {
-        // Calculate the element we grow with flex
-        let growContainer = scrollContainerHeight -
-          DOMUtil.getComputedDimensions(newState.scrollContainer).height;
-
-        // Check if the table can grow to take up the rest of its parent.
-        // If it can select the smallest viewport; parent or window.
-        if (growContainer > 0) {
-          newState.viewportHeight = scrollContainerHeight;
-        }
-      }
     }
 
     // Only update if we have a change
-    if (state.scrollContainer !== newState.scrollContainer ||
-      state.itemHeight !== newState.itemHeight ||
+    if (state.itemHeight !== newState.itemHeight ||
       state.viewportHeight !== newState.viewportHeight) {
       this.setState(newState);
     }
@@ -311,7 +285,6 @@ export default class Table extends React.Component {
 
   getScrollTable(columns, data, sortBy, itemHeight, containerHeight, idAttribute) {
     let classes = classNames(this.props.className, 'flush-bottom');
-    let scrollContainer = this.state.scrollContainer;
     let buildRowOptions = this.props.buildRowOptions;
     let childToMeasure;
 
@@ -333,7 +306,7 @@ export default class Table extends React.Component {
           {this.getEmptyRowCell(columns)}
         </tbody>
       );
-    } else if (scrollContainer != null) {
+    } else {
       style.height = containerHeight;
       let visibleItems = Math.ceil(containerHeight / itemHeight);
 
@@ -341,7 +314,7 @@ export default class Table extends React.Component {
       // with a max value cutoff.
       innerContent = (
         <VirtualList
-          container={scrollContainer}
+          container={window}
           itemBuffer={Math.min(200, 10 * visibleItems)}
           itemHeight={itemHeight}
           items={sortData(columns, data, sortBy)}
@@ -353,15 +326,10 @@ export default class Table extends React.Component {
     }
 
     return (
-      <GeminiScrollbar
-        autoshow={true}
-        ref="gemini"
-        style={style}>
-        <table className={classes}>
-          {this.props.colGroup}
-          {innerContent}
-        </table>
-      </GeminiScrollbar>
+      <table style={style} className={classes}>
+        {this.props.colGroup}
+        {innerContent}
+      </table>
     );
   }
 

--- a/src/Table/Table.js
+++ b/src/Table/Table.js
@@ -306,7 +306,7 @@ export default class Table extends React.Component {
           {this.getEmptyRowCell(columns)}
         </tbody>
       );
-    } else {
+    } else if (itemHeight !== 0) {
       style.height = containerHeight;
       let visibleItems = Math.ceil(containerHeight / itemHeight);
 

--- a/src/Table/Table.js
+++ b/src/Table/Table.js
@@ -51,6 +51,7 @@ export default class Table extends React.Component {
       sortBy: {}
     };
     this.cachedRows = {};
+    this.container = window;
   }
 
   componentWillMount() {
@@ -81,6 +82,12 @@ export default class Table extends React.Component {
     let props = this.props;
     let state = this.state;
     let refs = this.refs;
+
+    if (this.props.containerSelector && this.container === window) {
+      this.container = DOMUtil.closest(
+        React.findDOMNode(this), this.props.containerSelector
+      );
+    }
 
     if (props.itemHeight == null &&
       state.itemHeight == null &&
@@ -314,7 +321,7 @@ export default class Table extends React.Component {
       // with a max value cutoff.
       innerContent = (
         <VirtualList
-          container={window}
+          container={this.container}
           itemBuffer={Math.min(200, 10 * visibleItems)}
           itemHeight={itemHeight}
           items={sortData(columns, data, sortBy)}
@@ -422,6 +429,9 @@ Table.propTypes = {
       sortFunction: PropTypes.func
     })
   ).isRequired,
+
+  // Optional selector to use as container.
+  containerSelector: PropTypes.string,
 
   // Data to display in the table.
   // Make sure to clone the data, cannot be modified!

--- a/src/Table/__tests__/Table-test.js
+++ b/src/Table/__tests__/Table-test.js
@@ -44,17 +44,6 @@ describe('Table', function () {
       .toEqual(4);
   });
 
-  it('should render the proper number of rows', function () {
-    var rows = this.instance.getRows(
-      MockTable.rows,
-      MockTable.columns,
-      this.sortBy,
-      Util.noop,
-      this.idAttribute
-    );
-    expect(rows.length).toEqual(5);
-  });
-
   it('should call the callback when the data is sorted', function () {
     this.instance.handleSort();
     expect(this.callback).toHaveBeenCalled();

--- a/src/VirtualList/VirtualList.js
+++ b/src/VirtualList/VirtualList.js
@@ -93,6 +93,17 @@ export default class VirtualList extends Util.mixin(BindMixin) {
       viewTop = container.scrollTop;
     }
 
+    if (this.refs.list) {
+      let listBounding = React.findDOMNode(
+        this.refs.list
+      ).getBoundingClientRect();
+
+      let elementTop = listBounding.top +
+        (container.pageYOffset || container.scrollTop || 0);
+
+      viewTop -= elementTop;
+    }
+
     let renderStats = VirtualList.getItems(
       viewTop,
       viewHeight,
@@ -144,7 +155,7 @@ export default class VirtualList extends Util.mixin(BindMixin) {
     }
 
     return (
-    <props.tagName {...props}>
+    <props.tagName ref="list" {...props}>
       {props.renderBufferItem(topStyles)}
       {state.items.map(props.renderItem)}
       {props.renderBufferItem(bottomStyles)}


### PR DESCRIPTION
# Changes
* removes GeminiScrollbar from Table
* does not cap height of Table
* adds containerSelector functionality (ex. pass in `.container` and it will find the closest ancestor and use that as the container)
* only use a single table, instead of having two tables (for scrollbar)