### PR TITLE
Remove unnecessary code in VirtualList

### DIFF
--- a/src/Util/Util.js
+++ b/src/Util/Util.js
@@ -442,6 +442,13 @@ const Util = {
     return a.length !== b.length;
   },
 
+  /**
+   * @param {Function} func A callback function to be called
+   * @param {Number} wait How long to wait
+   * @returns {Function} A function, that, as long as it continues to be
+   * invoked, will not be triggered. The function will be called
+   * after it stops being called for N milliseconds.
+   */
   throttle(func, wait) {
     let canCall = true;
 

--- a/src/Util/Util.js
+++ b/src/Util/Util.js
@@ -442,6 +442,23 @@ const Util = {
     return a.length !== b.length;
   },
 
+  throttle(func, wait) {
+    let canCall = true;
+
+    let resetCall = function () {
+      console.log('%%$#%$');
+      canCall = true;
+    };
+
+    return function () {
+      if (canCall) {
+        setTimeout(resetCall, wait);
+        canCall = false;
+        func.apply(this, arguments);
+      }
+    };
+  },
+
   // Add external lodash functions
   noop: noop,
   trueNoop: trueNoop,
@@ -457,7 +474,6 @@ const Util = {
   pick: pick,
   sortBy: sortBy,
   values: values
-
 };
 
 export default Util;

--- a/src/Util/Util.js
+++ b/src/Util/Util.js
@@ -446,7 +446,6 @@ const Util = {
     let canCall = true;
 
     let resetCall = function () {
-      console.log('%%$#%$');
       canCall = true;
     };
 

--- a/src/Util/__tests__/Util-test.js
+++ b/src/Util/__tests__/Util-test.js
@@ -102,4 +102,32 @@ describe('Util', function () {
       expect(this.object).toEqual(expectedResult);
     });
   });
+
+  describe('#throttle', function () {
+    beforeEach(function () {
+      this.func = jest.genMockFunction();
+      this.throttled = Util.throttle(this.func, 200);
+    });
+
+    it('only calls once if called before the wait is finished', function () {
+      this.throttled();
+      this.throttled();
+      this.throttled();
+      this.throttled();
+      expect(this.func.mock.calls.length).toBe(1);
+    });
+
+    it('calls the function if called after the wait', function () {
+      var throttled = this.throttled;
+      var func = this.func;
+
+      throttled();
+      throttled();
+      throttled();
+      setTimeout(throttled, 200);
+      jest.runAllTimers();
+
+      expect(func.mock.calls.length).toBe(2);
+    });
+  });
 });

--- a/src/VirtualList/VirtualList.js
+++ b/src/VirtualList/VirtualList.js
@@ -28,32 +28,34 @@ export default class VirtualList extends Util.mixin(BindMixin) {
     };
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (this.props.container !== nextProps.container) {
-      this.props.container.removeEventListener('scroll', this.onScrollDebounced);
-      nextProps.container.addEventListener('scroll', this.onScrollDebounced);
-    }
-    let state = this.getVirtualState(nextProps);
-    this.setState(state);
-  }
-
   componentWillMount() {
-    this.onScrollDebounced = Util.throttle(
-      this.onScroll,
-      this.props.scrollDelay
-    );
+    // Replace onScroll by debouncing
+    if (this.props.scrollDelay > 0) {
+      this.onScroll = Util.throttle(this.onScroll, this.props.scrollDelay);
+    }
   }
 
   componentDidMount() {
     let props = this.props;
     let state = this.getVirtualState(props);
+
     this.setState(state);
-    props.container.addEventListener('scroll', this.onScrollDebounced);
+    props.container.addEventListener('scroll', this.onScroll);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (this.props.container !== nextProps.container) {
+      this.props.container.removeEventListener('scroll', this.onScroll);
+      nextProps.container.addEventListener('scroll', this.onScroll);
+    }
+
+    let state = this.getVirtualState(nextProps);
+    this.setState(state);
   }
 
   componentWillUnmount() {
     let props = this.props;
-    props.container.removeEventListener('scroll', this.onScrollDebounced);
+    props.container.removeEventListener('scroll', this.onScroll);
   }
 
   onScroll() {

--- a/src/VirtualList/VirtualList.js
+++ b/src/VirtualList/VirtualList.js
@@ -7,6 +7,7 @@
 import BindMixin from '../Mixin/BindMixin';
 import React from 'react';
 import Util from '../Util/Util';
+import DOMUtil from '../Util/DOMUtil';
 
 let mathMax = Math.max;
 let mathMin = Math.min;
@@ -18,7 +19,8 @@ export default class VirtualList extends Util.mixin(BindMixin) {
     return ['onScroll'];
   }
   constructor() {
-    super(arguments);
+    super(...arguments);
+
     this.state = {
       bufferEnd: 0,
       bufferStart: 0,
@@ -27,15 +29,18 @@ export default class VirtualList extends Util.mixin(BindMixin) {
   }
 
   componentWillReceiveProps(nextProps) {
+    if (this.props.container !== nextProps.container) {
+      this.props.container.removeEventListener('scroll', this.onScrollDebounced);
+      nextProps.container.addEventListener('scroll', this.onScrollDebounced);
+    }
     let state = this.getVirtualState(nextProps);
     this.setState(state);
   }
 
   componentWillMount() {
-    this.onScrollDebounced = Util.debounce(
+    this.onScrollDebounced = Util.throttle(
       this.onScroll,
-      this.props.scrollDelay,
-      false
+      this.props.scrollDelay
     );
   }
 
@@ -43,7 +48,6 @@ export default class VirtualList extends Util.mixin(BindMixin) {
     let props = this.props;
     let state = this.getVirtualState(props);
     this.setState(state);
-
     props.container.addEventListener('scroll', this.onScrollDebounced);
   }
 
@@ -67,24 +71,14 @@ export default class VirtualList extends Util.mixin(BindMixin) {
 
     // Early return if nothing to render
     if (typeof props.container === 'undefined' ||
-        props.items.length === 0 ||
-        props.itemHeight <= 0) {
+      props.items.length === 0 ||
+      props.itemHeight <= 0) {
       return state;
     }
 
     let items = props.items;
     let container = props.container;
-    let viewHeight;
-    if (typeof container.innerHeight !== 'undefined') {
-      viewHeight = container.innerHeight;
-    } else {
-      viewHeight = container.clientHeight;
-    }
-
-    // No space to render
-    if (viewHeight <= 0) {
-      return state;
-    }
+    let viewHeight = DOMUtil.getViewportHeight();
 
     let viewTop;
     if (typeof container.scrollY !== 'undefined') {
@@ -105,23 +99,13 @@ export default class VirtualList extends Util.mixin(BindMixin) {
     }
 
     let renderStats = VirtualList.getItems(
-      viewTop,
-      viewHeight,
-      0,
-      props.itemHeight,
-      items.length,
-      props.itemBuffer
+      viewTop, viewHeight, 0, props.itemHeight, items.length, props.itemBuffer
     );
-
-    // No items to render
-    if (renderStats.itemsInView.length === 0) {
-      return state;
-    }
 
     state.items = items.slice(
-      renderStats.firstItemIndex,
-      renderStats.lastItemIndex + 1
+      renderStats.firstItemIndex, renderStats.lastItemIndex + 1
     );
+
     state.bufferStart = renderStats.firstItemIndex * props.itemHeight;
     state.bufferEnd = (props.items.length - renderStats.lastItemIndex - 1) *
       props.itemHeight;
@@ -155,11 +139,11 @@ export default class VirtualList extends Util.mixin(BindMixin) {
     }
 
     return (
-    <props.tagName ref="list" {...props}>
-      {props.renderBufferItem(topStyles)}
-      {state.items.map(props.renderItem)}
-      {props.renderBufferItem(bottomStyles)}
-    </props.tagName>
+      <props.tagName ref="list" {...props}>
+        {props.renderBufferItem(topStyles)}
+        {state.items.map(props.renderItem)}
+        {props.renderBufferItem(bottomStyles)}
+      </props.tagName>
     );
   }
 
@@ -178,7 +162,8 @@ VirtualList.getItems = function (viewTop, viewHeight, listTop, itemHeight,
   itemCount, itemBuffer) {
   if (itemCount === 0 || itemHeight === 0) {
     return {
-      itemsInView: 0
+      firstItemIndex: 0,
+      lastItemIndex: 0
     };
   }
 
@@ -202,14 +187,16 @@ VirtualList.getItems = function (viewTop, viewHeight, listTop, itemHeight,
   // List is below viewport
   if (viewBox.bottom < listBox.top) {
     return {
-      itemsInView: 0
+      firstItemIndex: 0,
+      lastItemIndex: 0
     };
   }
 
   // List is above viewport
   if (viewBox.top > listBox.bottom) {
     return {
-      itemsInView: 0
+      firstItemIndex: 0,
+      lastItemIndex: 0
     };
   }
 
@@ -218,12 +205,9 @@ VirtualList.getItems = function (viewTop, viewHeight, listTop, itemHeight,
   let firstItemIndex = mathMax(0, mathFloor(listViewBox.top / itemHeight));
   let lastItemIndex = mathCeil(listViewBox.bottom / itemHeight) - 1;
 
-  let itemsInView = lastItemIndex - firstItemIndex + 1;
-
   let result = {
     firstItemIndex: firstItemIndex,
-    lastItemIndex: lastItemIndex,
-    itemsInView: itemsInView
+    lastItemIndex: lastItemIndex
   };
 
   return result;

--- a/src/VirtualList/VirtualList.js
+++ b/src/VirtualList/VirtualList.js
@@ -99,12 +99,16 @@ export default class VirtualList extends Util.mixin(BindMixin) {
     }
 
     let renderStats = VirtualList.getItems(
-      viewTop, viewHeight, 0, props.itemHeight, items.length, props.itemBuffer
+      viewTop,
+      viewHeight,
+      0,
+      props.itemHeight,
+      items.length,
+      props.itemBuffer
     );
 
-    state.items = items.slice(
-      renderStats.firstItemIndex, renderStats.lastItemIndex + 1
-    );
+    state.items =
+      items.slice(renderStats.firstItemIndex, renderStats.lastItemIndex + 1);
 
     state.bufferStart = renderStats.firstItemIndex * props.itemHeight;
     state.bufferEnd = (props.items.length - renderStats.lastItemIndex - 1) *
@@ -239,7 +243,7 @@ VirtualList.propTypes = {
   // Optional Specify which tag the container should render
   tagName: React.PropTypes.string,
 
-  // Optional scroll delay to use in debounce function
+  // Optional scroll delay to use in throttle function
   scrollDelay: React.PropTypes.number,
 
   // Optional number of items to use as buffer, before and after viewport

--- a/src/VirtualList/__tests__/VirtualList-test.js
+++ b/src/VirtualList/__tests__/VirtualList-test.js
@@ -1,7 +1,9 @@
-var VirtualList = require('../VirtualList');
-
 jest.dontMock('../VirtualList');
 jest.dontMock('../../Util/Util');
+jest.dontMock('../../Util/DOMUtil');
+jest.dontMock('../../Mixin/BindMixin');
+
+var VirtualList = require('../VirtualList');
 
 describe('VirtualList', function () {
 
@@ -131,40 +133,12 @@ describe('VirtualList', function () {
     var itemHeight = 200;
     var itemCount = 20;
 
-    it('shows items that are in the viewport', function () {
-      var windowScrollY = 0;
-      var offsetTop = 0;
-
-      var result = VirtualList.getItems(windowScrollY, viewport, offsetTop, itemHeight, itemCount, 0);
-
-      expect(result.itemsInView).toBeGreaterThan(0);
-    });
-
-    it('does not show items after the viewport', function () {
-      var windowScrollY = 0;
-      var offsetTop = 1000;
-
-      var result = VirtualList.getItems(windowScrollY, viewport, offsetTop, itemHeight, itemCount, 0);
-
-      expect(result.itemsInView).toBe(0);
-    });
-
-    it('does not show items before the viewport', function () {
-      var windowScrollY = 4000;
-      var offsetTop = 0;
-
-      var result = VirtualList.getItems(windowScrollY, viewport, offsetTop, itemHeight, itemCount, 0);
-
-      expect(result.itemsInView).toBe(0);
-    });
-
     it('shows the first 5 items at the top of the viewport', function () {
       var windowScrollY = 0;
       var offsetTop = 0;
 
       var result = VirtualList.getItems(windowScrollY, viewport, offsetTop, itemHeight, itemCount, 0);
 
-      expect(result.itemsInView).toBe(5);
       expect(result.firstItemIndex).toBe(0);
       expect(result.lastItemIndex).toBe(4);
     });
@@ -175,7 +149,6 @@ describe('VirtualList', function () {
 
       var result = VirtualList.getItems(windowScrollY, viewport, offsetTop, itemHeight, itemCount, 0);
 
-      expect(result.itemsInView).toBe(5);
       expect(result.firstItemIndex).toBe(15);
       expect(result.lastItemIndex).toBe(19);
     });
@@ -186,7 +159,8 @@ describe('VirtualList', function () {
 
       var result = VirtualList.getItems(windowScrollY, viewport, offsetTop, itemHeight, itemCount, 0);
 
-      expect(result.itemsInView).toBe(6);
+      expect(result.firstItemIndex).toBe(0);
+      expect(result.lastItemIndex).toBe(5);
     });
 
     it('shows the first 3 (2.5 items) if the list starts halfway down the page', function () {
@@ -196,7 +170,7 @@ describe('VirtualList', function () {
       var result = VirtualList.getItems(windowScrollY, viewport, offsetTop, itemHeight, itemCount, 0);
 
       expect(result.firstItemIndex).toBe(0);
-      expect(result.itemsInView).toBe(3);
+      expect(result.lastItemIndex).toBe(2);
     });
 
     it('shows the last 3 (2.5 items) if the viewport is scrolled 500px past the bottom of the list', function () {
@@ -206,7 +180,7 @@ describe('VirtualList', function () {
       var result = VirtualList.getItems(windowScrollY, viewport, offsetTop, itemHeight, itemCount, 0);
 
       expect(result.firstItemIndex).toBe(17);
-      expect(result.itemsInView).toBe(3);
+      expect(result.lastItemIndex).toBe(19);
     });
 
     it('shows all items if the list is smaller than the viewbox', function () {
@@ -216,7 +190,6 @@ describe('VirtualList', function () {
       var result = VirtualList.getItems(windowScrollY, viewport, offsetTop, itemHeight, 4, 0);
 
       expect(result.firstItemIndex).toBe(0);
-      expect(result.itemsInView).toBe(4);
       expect(result.lastItemIndex).toBe(3);
     });
 
@@ -226,7 +199,8 @@ describe('VirtualList', function () {
 
       var result = VirtualList.getItems(windowScrollY, viewport, offsetTop, itemHeight, itemCount, 5);
 
-      expect(result.itemsInView).toBeGreaterThan(5);
+      expect(result.firstItemIndex).toBe(0);
+      expect(result.lastItemIndex).toBe(9);
     });
 
     it('does not show items after the viewport, beyond the buffer', function () {
@@ -235,7 +209,8 @@ describe('VirtualList', function () {
 
       var result = VirtualList.getItems(windowScrollY, viewport, offsetTop, itemHeight, itemCount, 5);
 
-      expect(result.itemsInView).toBe(5);
+      expect(result.firstItemIndex).toBe(0);
+      expect(result.lastItemIndex).toBe(4);
     });
 
     it('does not show items before the viewport, beyond the buffer', function () {
@@ -244,13 +219,15 @@ describe('VirtualList', function () {
 
       var result = VirtualList.getItems(windowScrollY, viewport, offsetTop, itemHeight, itemCount, 5);
 
-      expect(result.itemsInView).toBe(5);
+      expect(result.firstItemIndex).toBe(15);
+      expect(result.lastItemIndex).toBe(19);
     });
 
     it('shows items before and after the viewport, in the buffer', function () {
       var result = VirtualList.getItems(1000, viewport, 0, itemHeight, itemCount, 5);
 
-      expect(result.itemsInView).toBe(15);
+      expect(result.firstItemIndex).toBe(0);
+      expect(result.lastItemIndex).toBe(14);
     });
   });
 });


### PR DESCRIPTION
# Changes
* remove the concept of `itemsInView` and use strictly `firstItemIndex` / `lastItemIndex`
* if container changes, reset scroll listeners
* throttle instead of debounce scroll event