### PR TITLE
Allow a custom function to be passed into showLabel

### DIFF
--- a/docs/src/Form/index.js
+++ b/docs/src/Form/index.js
@@ -49,7 +49,7 @@ class FormExample extends React.Component {
             checked: false
           }
         ],
-        description: 'What is your role?',
+        showLabel: 'What is your role?',
         name: 'role',
         validation: function (value) {
           let result = false;
@@ -192,7 +192,7 @@ class FormExample extends React.Component {
             checked: false
           }
         ],
-        description: 'What is your role?',
+        showLabel: 'What is your role?',
         name: 'role',
         validation: function (value) {
           let result = false;

--- a/src/Form/FieldCheckbox.js
+++ b/src/Form/FieldCheckbox.js
@@ -58,8 +58,8 @@ export default class FieldCheckbox extends Util.mixin(BindMixin) {
       label = showLabel;
     }
 
-    if (Util.isFunction(showLabel)) {
-      return showLabel();
+    if (typeof showLabel !== 'string' && showLabel !== true) {
+      return showLabel;
     }
 
     return (

--- a/src/Form/FieldCheckbox.js
+++ b/src/Form/FieldCheckbox.js
@@ -124,7 +124,7 @@ FieldCheckbox.propTypes = {
   // (usually passed down from form definition)
   handleEvent: React.PropTypes.func,
   // Optional boolean, string, or react node.
-  // If boolean: true shows name as label; false shows nothing.
+  // If boolean: true - shows name as label; false - shows nothing.
   // If string: shows string as label.
   // If node: returns the node as the label.
   showLabel: React.PropTypes.string,

--- a/src/Form/FieldCheckbox.js
+++ b/src/Form/FieldCheckbox.js
@@ -123,8 +123,11 @@ FieldCheckbox.propTypes = {
   // Function to handle change event
   // (usually passed down from form definition)
   handleEvent: React.PropTypes.func,
-  // Optional description for field
-  description: React.PropTypes.string,
+  // Optional boolean, string, or react node.
+  // If boolean: true shows name as label; false shows nothing.
+  // If string: shows string as label.
+  // If node: returns the node as the label.
+  showLabel: React.PropTypes.string,
   // Array of checkbox states to render
   // (usually passed down from value in form definition)
   startValue: React.PropTypes.array.isRequired,

--- a/src/Form/FieldCheckbox.js
+++ b/src/Form/FieldCheckbox.js
@@ -45,15 +45,26 @@ export default class FieldCheckbox extends Util.mixin(BindMixin) {
     return errorMsg;
   }
 
-  getDescription() {
+  getLabel() {
     let {props} = this;
-    if (!props.description) {
+    let label = props.name;
+    let showLabel = props.showLabel;
+
+    if (!showLabel) {
       return null;
+    }
+
+    if (typeof showLabel === 'string') {
+      label = showLabel;
+    }
+
+    if (Util.isFunction(showLabel)) {
+      return showLabel();
     }
 
     return (
       <p className={props.descriptionClass}>
-        {props.description}
+        {label}
       </p>
     );
   }
@@ -90,7 +101,7 @@ export default class FieldCheckbox extends Util.mixin(BindMixin) {
     return (
       <div className={this.getRowClass(this.props)}>
         <div className={classes}>
-          {this.getDescription()}
+          {this.getLabel()}
           <div ref="checkboxes">
             {this.getItems()}
           </div>

--- a/src/Form/FieldCheckbox.js
+++ b/src/Form/FieldCheckbox.js
@@ -127,7 +127,11 @@ FieldCheckbox.propTypes = {
   // If boolean: true - shows name as label; false - shows nothing.
   // If string: shows string as label.
   // If node: returns the node as the label.
-  showLabel: React.PropTypes.string,
+  showLabel: React.PropTypes.oneOfType([
+    React.PropTypes.node,
+    React.PropTypes.string,
+    React.PropTypes.bool
+  ]),
   // Array of checkbox states to render
   // (usually passed down from value in form definition)
   startValue: React.PropTypes.array.isRequired,

--- a/src/Form/FieldInput.js
+++ b/src/Form/FieldInput.js
@@ -184,7 +184,7 @@ FieldInput.propTypes = {
   // (usually passed down from form definition)
   name: React.PropTypes.string.isRequired,
   // Optional boolean, string, or react node.
-  // If boolean: true shows name as label; false shows nothing.
+  // If boolean: true - shows name as label; false - shows nothing.
   // If string: shows string as label.
   // If node: returns the node as the label.
   showLabel: React.PropTypes.bool,

--- a/src/Form/FieldInput.js
+++ b/src/Form/FieldInput.js
@@ -93,8 +93,8 @@ export default class FieldInput extends React.Component {
       label = showLabel;
     }
 
-    if (Util.isFunction(showLabel)) {
-      return showLabel();
+    if (typeof showLabel !== 'string' && showLabel !== true) {
+      return showLabel;
     }
 
     return (

--- a/src/Form/FieldInput.js
+++ b/src/Form/FieldInput.js
@@ -82,12 +82,23 @@ export default class FieldInput extends React.Component {
 
   getLabel() {
     let {props} = this;
-    if (!props.showLabel) {
+    let label = props.name;
+    let showLabel = props.showLabel;
+
+    if (!showLabel) {
       return null;
     }
 
+    if (typeof showLabel === 'string') {
+      label = showLabel;
+    }
+
+    if (Util.isFunction(showLabel)) {
+      return showLabel();
+    }
+
     return (
-      <label>{props.name}</label>
+      <label>{label}</label>
     );
   }
 

--- a/src/Form/FieldInput.js
+++ b/src/Form/FieldInput.js
@@ -183,7 +183,10 @@ FieldInput.propTypes = {
   // Name of the field property
   // (usually passed down from form definition)
   name: React.PropTypes.string.isRequired,
-  // Optional boolean, tells whether to show label, or not
+  // Optional boolean, string, or react node.
+  // If boolean: true shows name as label; false shows nothing.
+  // If string: shows string as label.
+  // If node: returns the node as the label.
   showLabel: React.PropTypes.bool,
   // initial value of checkbox, should be either 'checked' or 'unchecked'
   startValue: React.PropTypes.string,

--- a/src/Form/FieldInput.js
+++ b/src/Form/FieldInput.js
@@ -187,7 +187,11 @@ FieldInput.propTypes = {
   // If boolean: true - shows name as label; false - shows nothing.
   // If string: shows string as label.
   // If node: returns the node as the label.
-  showLabel: React.PropTypes.bool,
+  showLabel: React.PropTypes.oneOfType([
+    React.PropTypes.node,
+    React.PropTypes.string,
+    React.PropTypes.bool
+  ]),
   // initial value of checkbox, should be either 'checked' or 'unchecked'
   startValue: React.PropTypes.string,
   // Optional object of error messages, with key equal to field property name

--- a/src/Form/__tests__/FieldCheckbox-test.js
+++ b/src/Form/__tests__/FieldCheckbox-test.js
@@ -71,20 +71,35 @@ describe('FieldCheckbox', function () {
     });
   });
 
-  describe('#getDescription', function () {
-    it('should return a paragraph if description has a value', function () {
+  describe('#getLabel', function () {
+    it('should return a paragraph if showLabel has a value', function () {
       var instance = TestUtils.renderIntoDocument(
         <FieldCheckbox
           name="foo"
-          description="bar"
+          showLabel="bar"
           startValue={[]}
           fieldType="checkbox" />
       );
 
-      expect(instance.getDescription().type).toEqual('p');
+      expect(instance.getLabel().type).toEqual('p');
     });
 
-    it('should return null if description doesn\'t has a value', function () {
+    it('can handle a custom render function', function () {
+      var customRender = function () {
+        return <h1>hello</h1>
+      };
+      var instance = TestUtils.renderIntoDocument(
+        <FieldCheckbox
+          name="foo"
+          showLabel={customRender}
+          startValue={[]}
+          fieldType="checkbox" />
+      );
+
+      expect(instance.getLabel().type).toEqual('h1');
+    });
+
+    it('should return null if showLabel doesn\'t has a value', function () {
       var instance = TestUtils.renderIntoDocument(
         <FieldCheckbox
           name="foo"
@@ -92,7 +107,7 @@ describe('FieldCheckbox', function () {
           fieldType="checkbox" />
       );
 
-      expect(instance.getDescription()).toEqual(null);
+      expect(instance.getLabel()).toEqual(null);
     });
   });
 

--- a/src/Form/__tests__/FieldCheckbox-test.js
+++ b/src/Form/__tests__/FieldCheckbox-test.js
@@ -85,13 +85,10 @@ describe('FieldCheckbox', function () {
     });
 
     it('can handle a custom render function', function () {
-      var customRender = function () {
-        return <h1>hello</h1>
-      };
       var instance = TestUtils.renderIntoDocument(
         <FieldCheckbox
           name="foo"
-          showLabel={customRender}
+          showLabel={<h1>hello</h1>}
           startValue={[]}
           fieldType="checkbox" />
       );

--- a/src/Form/__tests__/FieldInput-test.js
+++ b/src/Form/__tests__/FieldInput-test.js
@@ -145,6 +145,22 @@ describe('FieldInput', function () {
       expect(instance.getLabel().type).toEqual('label');
     });
 
+    it('can handle a custom render function', function () {
+      var customRender = function () {
+        return <h1>hello</h1>
+      };
+      var instance = TestUtils.renderIntoDocument(
+        <FieldInput
+          name="username"
+          fieldType="text"
+          writeType="input"
+          handleEvent={function () {}}
+          showLabel={customRender} />
+      );
+
+      expect(instance.getLabel().type).toEqual('h1');
+    });
+
     it('should return null if showLabel is false', function () {
       var instance = TestUtils.renderIntoDocument(
         <FieldInput

--- a/src/Form/__tests__/FieldInput-test.js
+++ b/src/Form/__tests__/FieldInput-test.js
@@ -146,16 +146,13 @@ describe('FieldInput', function () {
     });
 
     it('can handle a custom render function', function () {
-      var customRender = function () {
-        return <h1>hello</h1>
-      };
       var instance = TestUtils.renderIntoDocument(
         <FieldInput
           name="username"
           fieldType="text"
           writeType="input"
           handleEvent={function () {}}
-          showLabel={customRender} />
+          showLabel={<h1>hello</h1>} />
       );
 
       expect(instance.getLabel().type).toEqual('h1');


### PR DESCRIPTION
the `showLabel` prop inside of definition can now have three possible value types:

* **boolean**: if true, will show the field name as a label. if false, will show nothing.
* **string**: will use string as label.
* **function**: will invoke and return the result of the function