### PR TITLE
Allow modals to get bigger as the viewport gets bigger

### DIFF
--- a/src/Modal/ModalContents.js
+++ b/src/Modal/ModalContents.js
@@ -84,12 +84,25 @@ class ModalContents extends Util.mixin(BindMixin) {
   checkContentHeightChange(prevHeightInfo, heightInfo) {
     let {height, maxHeight, innerContentHeight} = heightInfo;
     let prevContentHeight = prevHeightInfo.innerContentHeight;
+    let prevMaxHeight = prevHeightInfo.maxHeight;
+    let update = false;
 
     if (prevContentHeight != null) {
       let difference = innerContentHeight - prevContentHeight;
       if (difference !== 0 && height + difference < maxHeight) {
         heightInfo.height += difference;
         heightInfo.contentHeight += difference;
+        update = true;
+      }
+
+      let maxHeightDifference = maxHeight - prevMaxHeight;
+      if (maxHeightDifference > 0) {
+        heightInfo.height += maxHeightDifference;
+        heightInfo.contentHeight += maxHeightDifference;
+        update = true;
+      }
+
+      if (update) {
         this.forceUpdate();
       }
     }
@@ -127,7 +140,6 @@ class ModalContents extends Util.mixin(BindMixin) {
 
   getInnerContainerHeightInfo() {
     let innerContainer = this.refs.innerContainer;
-
     let originalHeight = React.findDOMNode(innerContainer).offsetHeight;
     let totalContentHeight = React.findDOMNode(this.refs.modal).offsetHeight;
 
@@ -149,7 +161,9 @@ class ModalContents extends Util.mixin(BindMixin) {
 
     // We minus the maxHeight with the outerHeight because it will
     // not show the content correctly due to 'box-sizing: border-box'.
-    contentHeight = Math.min(contentHeight, maxHeight - outerHeight);
+    if (contentHeight > maxHeight) {
+      contentHeight = maxHeight;
+    }
 
     return {
       contentHeight,

--- a/src/Modal/__tests__/ModalContents-test.js
+++ b/src/Modal/__tests__/ModalContents-test.js
@@ -227,6 +227,22 @@ describe('ModalContents', function () {
         expect(heightInfo.height).toEqual(600);
       }
     );
+
+    it('should update the heightInfo if maxHeight gets bigger', function () {
+      var prevHeightInfo = {innerContentHeight: 600, maxHeight: 400};
+      var heightInfo = {
+        innerContentHeight: 600,
+        maxHeight: 500,
+        contentHeight: 350,
+        height: 400
+      };
+
+      this.instance.checkContentHeightChange(prevHeightInfo, heightInfo);
+
+      // Adds the difference between the maxHeights to contentHeight and height.
+      expect(heightInfo.contentHeight).toEqual(450);
+      expect(heightInfo.height).toEqual(500);
+    });
   });
 
   describe('overflow hidden on body', function () {


### PR DESCRIPTION
Currently, if the modals are capped out at the `maxHeight` and the maxHeight gets bigger, the modal doesn't also get bigger. This fixes that.