### PR TITLE
fix Form module export

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,5 +1,6 @@
 var Confirm = require('./lib/Confirm/Confirm');
 var Dropdown = require('./lib/Dropdown/Dropdown');
+var Form = require('./lib/Form/Form');
 var List = require('./lib/List/List');
 var Modal = require('./lib/Modal/Modal');
 var SidePanel = require('./lib/SidePanel/SidePanel');
@@ -8,6 +9,7 @@ var Table = require('./lib/Table/Table');
 module.exports = {
   Confirm: Confirm,
   Dropdown: Dropdown,
+  Form: Form,
   List: List,
   Modal: Modal,
   SidePanel: SidePanel,

--- a/src/Form/Form.js
+++ b/src/Form/Form.js
@@ -13,7 +13,7 @@ function findFieldOption(options, field) {
   });
 }
 
-export default class Form extends Util.mixin(BindMixin) {
+class Form extends Util.mixin(BindMixin) {
   get methodsToBind() {
     return [
       'handleBlur',
@@ -314,3 +314,5 @@ Form.propTypes = {
   // Call the trigger function, when a submit needs to be triggered externally
   triggerSubmit: PropTypes.func
 };
+
+module.exports = Form;


### PR DESCRIPTION
Using `module.exports = {Component}` in compliance with Babel 6