### PR TITLE
Don’t show a single item when table not on screen

### DIFF
--- a/docs/src/Table/index.js
+++ b/docs/src/Table/index.js
@@ -545,19 +545,17 @@ class TableExample extends React.Component {
                     </p>
                   </div>
                 </div>
-                <div style={{height: 800}}>
-                  <GeminiScrollbar
-                    autoshow={true}
-                    className="container-scrollable">
-                    <Table
-                      className="table"
-                      colGroup={this.getColGroup()}
-                      columns={this.getColumns()}
-                      data={this.hugeRows}
-                      containerSelector=".gm-scroll-view"
-                      idAttribute="id" />
-                  </GeminiScrollbar>
-                </div>
+                <GeminiScrollbar
+                  autoshow={true}
+                  style={{height: 800}}>
+                  <Table
+                    className="table"
+                    colGroup={this.getColGroup()}
+                    columns={this.getColumns()}
+                    data={this.hugeRows}
+                    containerSelector=".gm-scroll-view"
+                    idAttribute="id" />
+                </GeminiScrollbar>
               </div>
               <div className="example-block-footer example-block-footer-codeblock">
                 <pre className="prettyprint linenums flush-bottom">

--- a/src/VirtualList/VirtualList.js
+++ b/src/VirtualList/VirtualList.js
@@ -206,7 +206,7 @@ VirtualList.getItems = function (viewTop, viewHeight, listTop, itemHeight,
   if (viewBox.bottom < listBox.top) {
     return {
       firstItemIndex: 0,
-      lastItemIndex: 0
+      lastItemIndex: (viewHeight / itemHeight) + itemBuffer
     };
   }
 
@@ -214,7 +214,7 @@ VirtualList.getItems = function (viewTop, viewHeight, listTop, itemHeight,
   if (viewBox.top > listBox.bottom) {
     return {
       firstItemIndex: 0,
-      lastItemIndex: 0
+      lastItemIndex: (viewHeight / itemHeight) + itemBuffer
     };
   }
 


### PR DESCRIPTION
Was trying to be clever before and only show 1 item when table was no on screen. This caused problems because if the container wasn't the window, it wouldn't refresh and show the full items when it was on the screen.

This fix will now show the necessary items whether the table is on the screen or not