### PR TITLE
Allow react elements in definition, allow custom render functions

### DIFF
--- a/src/Form/FieldInput.js
+++ b/src/Form/FieldInput.js
@@ -135,8 +135,8 @@ export default class FieldInput extends React.Component {
       );
     }
 
-    if (this.props.render) {
-      return this.props.render(inputContent);
+    if (this.props.renderer) {
+      return this.props.renderer(inputContent);
     }
 
     return inputContent;
@@ -191,7 +191,7 @@ FieldInput.propTypes = {
   // (usually passed down from form definition)
   name: React.PropTypes.string.isRequired,
   // Custom render function, receives the input element as its only argument
-  render: React.PropTypes.func,
+  renderer: React.PropTypes.func,
   // Optional boolean, string, or react node.
   // If boolean: true - shows name as label; false - shows nothing.
   // If string: shows string as label.

--- a/src/Form/FieldInput.js
+++ b/src/Form/FieldInput.js
@@ -104,12 +104,13 @@ export default class FieldInput extends React.Component {
 
   getInputElement(attributes) {
     let {props} = this;
+    let inputContent = null;
 
     let classes = classNames(props.inputClass, props.sharedClass);
     attributes = this.bindEvents(attributes);
 
     if (this.isEditing() || props.writeType === 'input') {
-      return (
+      inputContent = (
         <input
           ref="inputElement"
           className={classes}
@@ -117,22 +118,28 @@ export default class FieldInput extends React.Component {
           {...attributes}
           value={attributes.startValue} />
       );
+    } else {
+      inputContent = (
+        <span
+          ref="inputElement"
+          {...attributes}
+          className={classes}
+          onClick={attributes.onFocus}>
+          <span className={props.inlineTextClass}>
+            {props.value || attributes.startValue}
+          </span>
+          <span className={props.inlineIconClass}>
+            <IconEdit />
+          </span>
+        </span>
+      );
     }
 
-    return (
-      <span
-        ref="inputElement"
-        {...attributes}
-        className={classes}
-        onClick={attributes.onFocus}>
-        <span className={props.inlineTextClass}>
-          {props.value || attributes.startValue}
-        </span>
-        <span className={props.inlineIconClass}>
-          <IconEdit />
-        </span>
-      </span>
-    );
+    if (this.props.render) {
+      return this.props.render(inputContent);
+    }
+
+    return inputContent;
   }
 
   render() {
@@ -183,6 +190,8 @@ FieldInput.propTypes = {
   // Name of the field property
   // (usually passed down from form definition)
   name: React.PropTypes.string.isRequired,
+  // Custom render function, receives the input element as its only argument
+  render: React.PropTypes.func,
   // Optional boolean, string, or react node.
   // If boolean: true - shows name as label; false - shows nothing.
   // If string: shows string as label.

--- a/src/Form/FieldPassword.js
+++ b/src/Form/FieldPassword.js
@@ -30,6 +30,7 @@ export default class FieldPassword extends FieldInput {
 
   getInputElement(attributes) {
     let classes = classNames(this.props.inputClass, this.props.sharedClass);
+    let inputContent = null;
     attributes = this.bindEvents(attributes, this.props.handleEvent);
     attributes.onFocus = this.handleOnFocus;
 
@@ -39,7 +40,7 @@ export default class FieldPassword extends FieldInput {
     }
 
     if (this.isEditing() || this.props.writeType === 'input') {
-      return (
+      inputContent = (
         <input
           {...attributes}
           ref="inputElement"
@@ -47,22 +48,28 @@ export default class FieldPassword extends FieldInput {
           onKeyDown={this.handleKeyDown.bind(this)}
           value={startValue} />
       );
+    } else {
+      inputContent = (
+        <span
+          ref="inputElement"
+          {...attributes}
+          className={classes}
+          onClick={attributes.onFocus}>
+          <span className={this.props.inlineTextClass}>
+            {attributes.defaultPasswordValue || DEFAULT_PASSWORD_TEXT}
+          </span>
+          <span className={this.props.inlineIconClass}>
+            <IconEdit />
+          </span>
+        </span>
+      );
     }
 
-    return (
-      <span
-        ref="inputElement"
-        {...attributes}
-        className={classes}
-        onClick={attributes.onFocus}>
-        <span className={this.props.inlineTextClass}>
-          {attributes.defaultPasswordValue || DEFAULT_PASSWORD_TEXT}
-        </span>
-        <span className={this.props.inlineIconClass}>
-          <IconEdit />
-        </span>
-      </span>
-    );
+    if (this.props.render) {
+      return this.props.render(inputContent);
+    }
+
+    return inputContent;
   }
 
 }

--- a/src/Form/FieldPassword.js
+++ b/src/Form/FieldPassword.js
@@ -65,8 +65,8 @@ export default class FieldPassword extends FieldInput {
       );
     }
 
-    if (this.props.render) {
-      return this.props.render(inputContent);
+    if (this.props.renderer) {
+      return this.props.renderer(inputContent);
     }
 
     return inputContent;

--- a/src/Form/Form.js
+++ b/src/Form/Form.js
@@ -191,6 +191,9 @@ class Form extends Util.mixin(BindMixin) {
   buildStateObj(definition, fieldProp) {
     let stateObj = {};
     Util.flatten(definition).forEach(function (formControlOption) {
+      if (React.isValidElement(formControlOption)) {
+        return;
+      }
       stateObj[formControlOption.name] = formControlOption[fieldProp] || null;
     });
 
@@ -227,6 +230,14 @@ class Form extends Util.mixin(BindMixin) {
     ]);
 
     return definition.map((formControlOption, i) => {
+      if (React.isValidElement(formControlOption)) {
+        return (
+          <span key={i}>
+            {formControlOption}
+          </span>
+        );
+      }
+
       // Map each field to showError boolean
       let showError =
         this.buildFormPropObj(formControlOption, state.erroredFields);

--- a/src/Form/Form.js
+++ b/src/Form/Form.js
@@ -191,6 +191,8 @@ class Form extends Util.mixin(BindMixin) {
   buildStateObj(definition, fieldProp) {
     let stateObj = {};
     Util.flatten(definition).forEach(function (formControlOption) {
+      // If the element is a React element, then we don't want to add it to the
+      // state object, which represents the form values.
       if (React.isValidElement(formControlOption)) {
         return;
       }
@@ -230,6 +232,8 @@ class Form extends Util.mixin(BindMixin) {
     ]);
 
     return definition.map((formControlOption, i) => {
+      // If it's a React element, we just want to return it. We need to add a
+      // key to the object because we're iterating over a list of items.
       if (React.isValidElement(formControlOption)) {
         return (
           <span key={i}>

--- a/src/Form/__tests__/FieldInput-test.js
+++ b/src/Form/__tests__/FieldInput-test.js
@@ -118,20 +118,20 @@ describe('FieldInput', function () {
       expect(instance.getInputElement({}).type).toEqual('input');
     });
 
-    it('should return an input if writeType is input', function () {
+    it('should return its custom render function', function () {
       var instance = TestUtils.renderIntoDocument(
         <FieldInput
           name="username"
           fieldType="text"
           writeType="input"
           handleEvent={function () {}}
-          render={function () { return 'foo'; }} />
+          renderer={function () { return 'foo'; }} />
       );
 
       expect(instance.getInputElement({})).toEqual('foo');
     });
 
-    it('should return its custom render funciton', function () {
+    it('should return an input if writeType is input', function () {
       var instance = TestUtils.renderIntoDocument(
         <FieldInput
           name="username"

--- a/src/Form/__tests__/FieldInput-test.js
+++ b/src/Form/__tests__/FieldInput-test.js
@@ -128,7 +128,7 @@ describe('FieldInput', function () {
           render={function () { return 'foo'; }} />
       );
 
-      expect(instance.getInputElement()).toEqual('foo');
+      expect(instance.getInputElement({})).toEqual('foo');
     });
 
     it('should return its custom render funciton', function () {

--- a/src/Form/__tests__/FieldInput-test.js
+++ b/src/Form/__tests__/FieldInput-test.js
@@ -124,6 +124,19 @@ describe('FieldInput', function () {
           name="username"
           fieldType="text"
           writeType="input"
+          handleEvent={function () {}}
+          render={function () { return 'foo'; }} />
+      );
+
+      expect(instance.getInputElement()).toEqual('foo');
+    });
+
+    it('should return its custom render funciton', function () {
+      var instance = TestUtils.renderIntoDocument(
+        <FieldInput
+          name="username"
+          fieldType="text"
+          writeType="input"
           handleEvent={function () {}} />
       );
 

--- a/src/Form/__tests__/Form-test.js
+++ b/src/Form/__tests__/Form-test.js
@@ -176,5 +176,10 @@ describe('Form', function () {
         expect(formControl.type).toEqual(FormControl);
       });
     });
+
+    it('accepts a React element and returns it', function () {
+      this.instance = getInstance([<h1>foo</h1>], noop, noop);
+      expect(TestUtils.findRenderedDOMComponentWithTag(this.instance, 'h1'));
+    });
   });
 });


### PR DESCRIPTION
This introduces two features:
* Allows users to pass a custom `render` function for each form element. The custom `render` function receives the input element and is expected to return a transformed element, or the same element, in its place.
* Allows users the ability to pass components as items in the `definition` array, which will not be modified in any way by the component.