### PR TITLE
Remove default password

### DIFF
--- a/src/Form/FieldPassword.js
+++ b/src/Form/FieldPassword.js
@@ -6,8 +6,6 @@ import React from 'react';
 import FieldInput from './FieldInput';
 import IconEdit from './icons/IconEdit';
 
-const DEFAULT_PASSWORD_TEXT = '••••••';
-
 const METHODS_TO_BIND = ['handleOnFocus'];
 
 export default class FieldPassword extends FieldInput {
@@ -34,10 +32,7 @@ export default class FieldPassword extends FieldInput {
     attributes = this.bindEvents(attributes, this.props.handleEvent);
     attributes.onFocus = this.handleOnFocus;
 
-    let startValue = DEFAULT_PASSWORD_TEXT;
-    if (this.focused) {
-      startValue = attributes.startValue;
-    }
+    let startValue = attributes.startValue || '';
 
     if (this.isEditing() || this.props.writeType === 'input') {
       inputContent = (

--- a/src/Form/FieldPassword.js
+++ b/src/Form/FieldPassword.js
@@ -6,7 +6,7 @@ import React from 'react';
 import FieldInput from './FieldInput';
 import IconEdit from './icons/IconEdit';
 
-const METHODS_TO_BIND = ['handleOnFocus'];
+const METHODS_TO_BIND = ['handleOnBlur', 'handleOnFocus'];
 
 export default class FieldPassword extends FieldInput {
   constructor() {
@@ -15,6 +15,15 @@ export default class FieldPassword extends FieldInput {
     METHODS_TO_BIND.forEach((method) => {
       this[method] = this[method].bind(this);
     });
+  }
+
+  handleOnBlur(event) {
+    if (this.focused) {
+      this.focused = false;
+      this.forceUpdate();
+    }
+
+    this.props.handleEvent('blur', this.props.name, event);
   }
 
   handleOnFocus(event) {
@@ -30,9 +39,15 @@ export default class FieldPassword extends FieldInput {
     let classes = classNames(this.props.inputClass, this.props.sharedClass);
     let inputContent = null;
     attributes = this.bindEvents(attributes, this.props.handleEvent);
+    attributes.onBlur = this.handleOnBlur;
     attributes.onFocus = this.handleOnFocus;
 
-    let startValue = attributes.startValue || '';
+    let fieldValue = attributes.defaultPasswordValue ||
+      attributes.startValue || '';
+
+    if (this.focused) {
+      fieldValue = attributes.startValue;
+    }
 
     if (this.isEditing() || this.props.writeType === 'input') {
       inputContent = (
@@ -41,7 +56,7 @@ export default class FieldPassword extends FieldInput {
           ref="inputElement"
           className={classes}
           onKeyDown={this.handleKeyDown.bind(this)}
-          value={startValue} />
+          value={fieldValue} />
       );
     } else {
       inputContent = (


### PR DESCRIPTION
This removes the default password string, which displayed the same string for password fields whenever they were not in focus.

By default it will behave as a regular password input field, where it's empty to start and then displays the obfuscated password as the user enters it. On blur, the obfuscated password remains.

Users can specify a `defaultPasswordValue` which will be displayed when a password field does not have focus, in order to hide the length of the actual password in the input field.

In this example, the `defaultPasswordValue` is set to a two-character string:
![](https://s3.amazonaws.com/f.cl.ly/items/380R2t2s3d1q1s1W1B2W/Screen%20Recording%202016-01-15%20at%2001.22%20PM.gif?v=17385771)