### PR TITLE
Turn table cell caching off by default

### DIFF
--- a/docs/src/Table/index.js
+++ b/docs/src/Table/index.js
@@ -164,7 +164,6 @@ class TableExample extends React.Component {
     return [
       {
         className: 'name',
-        dontCache: true,
         heading: this.getColumnHeading,
         prop: 'name',
         sortable: true
@@ -173,6 +172,7 @@ class TableExample extends React.Component {
         // sortFunction: getSortFunction('age')
       },
       {
+        cacheCell: true,
         className: 'age',
         heading: this.getColumnHeading,
         prop: 'age',
@@ -180,6 +180,7 @@ class TableExample extends React.Component {
         sortFunction: getSortFunction('name')
       },
       {
+        cacheCell: true,
         className: 'location',
         defaultContent: 'None Specified',
         heading: this.getColumnHeading,
@@ -188,6 +189,7 @@ class TableExample extends React.Component {
         sortFunction: getSortFunction('name')
       },
       {
+        cacheCell: true,
         className: 'gender',
         heading: this.getColumnHeading,
         prop: 'gender',
@@ -331,7 +333,6 @@ class TableExample extends React.Component {
     // The first column will be a "name" column.
     {
       className: 'name',
-      dontCache: true,
       heading: this.getColumnHeading,
       prop: 'name',
       sortable: true
@@ -341,6 +342,7 @@ class TableExample extends React.Component {
       // sortFunction: getSortFunction('age')
     },
     {
+      cacheCell: true,
       className: 'age',
       heading: this.getColumnHeading,
       prop: 'age',
@@ -348,6 +350,7 @@ class TableExample extends React.Component {
       sortFunction: getSortFunction('name')
     },
     {
+      cacheCell: true,
       className: 'location',
       defaultContent: 'None Specified',
       heading: this.getColumnHeading,
@@ -356,6 +359,7 @@ class TableExample extends React.Component {
       sortFunction: getSortFunction('name')
     },
     {
+      cacheCell: true,
       className: 'gender',
       heading: this.getColumnHeading,
       prop: 'gender',

--- a/src/Table/Table.js
+++ b/src/Table/Table.js
@@ -179,7 +179,7 @@ class Table extends React.Component {
       let cellValue = row[prop];
       let cellID;
 
-      if (!column.dontCache) {
+      if (column.cacheCell === true) {
         cellID = this.buildUniqueID(cellClassName, cellValue, prop);
       }
 
@@ -200,7 +200,7 @@ class Table extends React.Component {
           </td>
         );
 
-        if (column.dontCache) {
+        if (!column.cacheCell) {
           return cellElement;
         }
 
@@ -324,8 +324,8 @@ Table.propTypes = {
         PropTypes.func
       ]),
       defaultContent: PropTypes.string,
-      // Column cached by default; disable with this setting.
-      dontCache: PropTypes.bool,
+      // Enable caching of cells for better performance.
+      cacheCell: PropTypes.bool,
       heading: PropTypes.oneOfType([
         PropTypes.string,
         PropTypes.func


### PR DESCRIPTION
Turning caching on by default makes the table harder to use up front + caching is only for niche cases.