### PR TITLE
Extend handleEvent to pass more event information

### DIFF
--- a/src/Form/FieldPassword.js
+++ b/src/Form/FieldPassword.js
@@ -23,7 +23,7 @@ export default class FieldPassword extends FieldInput {
       this.forceUpdate();
     }
 
-    this.props.handleEvent('blur', this.props.name, event.target.value);
+    this.props.handleEvent('blur', this.props.name, event.target.value, event);
   }
 
   handleOnFocus(event) {
@@ -32,7 +32,7 @@ export default class FieldPassword extends FieldInput {
       this.forceUpdate();
     }
 
-    this.props.handleEvent('focus', this.props.name, event.target.value);
+    this.props.handleEvent('focus', this.props.name, event.target.value, event);
   }
 
   getInputElement(attributes) {

--- a/src/Form/FieldPassword.js
+++ b/src/Form/FieldPassword.js
@@ -23,7 +23,7 @@ export default class FieldPassword extends FieldInput {
       this.forceUpdate();
     }
 
-    this.props.handleEvent('blur', this.props.name, event);
+    this.props.handleEvent('blur', this.props.name, event.target.value);
   }
 
   handleOnFocus(event) {
@@ -32,7 +32,7 @@ export default class FieldPassword extends FieldInput {
       this.forceUpdate();
     }
 
-    this.props.handleEvent('focus', this.props.name, event);
+    this.props.handleEvent('focus', this.props.name, event.target.value);
   }
 
   getInputElement(attributes) {

--- a/src/Form/Form.js
+++ b/src/Form/Form.js
@@ -70,7 +70,9 @@ class Form extends Util.mixin(BindMixin) {
     this.setState(nextState);
   }
 
-  handleEvent(eventType, fieldName, fieldValue) {
+  handleEvent(eventType, fieldName, fieldValue, event) {
+    let eventObj = {fieldName, fieldValue, event};
+
     switch (eventType) {
       case 'blur':
         this.handleBlur(fieldName);
@@ -85,7 +87,7 @@ class Form extends Util.mixin(BindMixin) {
         this.handleMultipleChange(fieldName, fieldValue);
     }
 
-    this.props.onChange(this.state.model);
+    this.props.onChange(this.state.model, eventObj);
   }
 
   handleSubmit(event) {


### PR DESCRIPTION
For each event, `handleEvent` will pass the `fieldName` and `fieldValue` of the element that triggered the event, as well as the event object itself.