### PR TITLE
Expose scrollbar and height adjustment in Modal

### DIFF
--- a/docs/src/Modal/index.js
+++ b/docs/src/Modal/index.js
@@ -47,6 +47,8 @@ class ModalExample extends React.Component {
               <div className="example-block">
                 <pre className="prettyprint linenums flush-bottom">
 {`ModalContents.propTypes = {
+  // Allow resize of modal to fit screen. Defaults to true.
+  dynamicHeight: PropTypes.bool,
   children: PropTypes.node,
   // Allow closing of modal when click happens outside modal. Defaults to true.
   closeByBackdropClick: PropTypes.bool,
@@ -72,8 +74,8 @@ class ModalExample extends React.Component {
   transitionNameBackdrop: PropTypes.string,
   // Optional enter and leave transition name for modal
   transitionNameModal: PropTypes.string,
-  // Optionally disable scrollbar to allow overflow (such as a dropdown).
-  useScrollbar: PropTypes.bool,
+  // Optional disable Gemini scrollbar. Defaults to true.
+  useGemini: PropTypes.bool,
 
   // Classes
   backdropClass: PropTypes.string,

--- a/docs/src/Modal/index.js
+++ b/docs/src/Modal/index.js
@@ -72,6 +72,8 @@ class ModalExample extends React.Component {
   transitionNameBackdrop: PropTypes.string,
   // Optional enter and leave transition name for modal
   transitionNameModal: PropTypes.string,
+  // Optionally disable scrollbar to allow overflow (such as a dropdown).
+  useScrollbar: PropTypes.bool,
 
   // Classes
   backdropClass: PropTypes.string,

--- a/src/Modal/ModalContents.js
+++ b/src/Modal/ModalContents.js
@@ -282,17 +282,11 @@ class ModalContents extends Util.mixin(BindMixin) {
     }
 
     let calculatedHeight = this.heightInfo;
-
     let contentHeight = calculatedHeight.contentHeight;
-    let modalStyle = {height: calculatedHeight.height};
+    let modalStyle = null;
 
-    let useScrollbar = this.props.useScrollbar;
-    if (useScrollbar === null) {
-      if (calculatedHeight.height !== 'auto') {
-        useScrollbar = true;
-      } else {
-        useScrollbar = false;
-      }
+    if (this.props.dynamicHeight) {
+      modalStyle = {height: calculatedHeight.height};
     }
 
     return (
@@ -302,7 +296,7 @@ class ModalContents extends Util.mixin(BindMixin) {
           {this.getHeader()}
           <div className={props.bodyClass} style={modalStyle}>
             <div ref="innerContainer" className={props.innerBodyClass}>
-              {this.getModalContent(useScrollbar, contentHeight)}
+              {this.getModalContent(this.props.useGemini, contentHeight)}
             </div>
           </div>
           {this.getFooter()}
@@ -345,6 +339,7 @@ class ModalContents extends Util.mixin(BindMixin) {
 }
 
 ModalContents.defaultProps = {
+  dynamicHeight: true,
   closeByBackdropClick: true,
   footer: null,
   maxHeightPercentage: 0.6,
@@ -357,7 +352,7 @@ ModalContents.defaultProps = {
   titleText: '',
   transitionNameBackdrop: 'modal-backdrop',
   transitionNameModal: 'modal',
-  useScrollbar: null,
+  useGemini: true,
 
   // Default classes.
   backdropClass: 'modal-backdrop',
@@ -377,6 +372,8 @@ ModalContents.defaultProps = {
 };
 
 ModalContents.propTypes = {
+  // Allow resize of modal to fit screen. Defaults to true.
+  dynamicHeight: PropTypes.bool,
   children: PropTypes.node,
   // Allow closing of modal when click happens outside modal. Defaults to true.
   closeByBackdropClick: PropTypes.bool,
@@ -402,8 +399,8 @@ ModalContents.propTypes = {
   transitionNameBackdrop: PropTypes.string,
   // Optional enter and leave transition name for modal
   transitionNameModal: PropTypes.string,
-  // Optionally disable scrollbar to allow overflow (such as a dropdown).
-  useScrollbar: PropTypes.bool,
+  // Optional disable Gemini scrollbar. Defaults to true.
+  useGemini: PropTypes.bool,
 
   // Classes
   backdropClass: PropTypes.string,

--- a/src/Modal/ModalContents.js
+++ b/src/Modal/ModalContents.js
@@ -283,10 +283,15 @@ class ModalContents extends Util.mixin(BindMixin) {
 
     let calculatedHeight = this.heightInfo;
     let contentHeight = calculatedHeight.contentHeight;
-    let modalStyle = null;
 
+    let modalStyle = null;
     if (this.props.dynamicHeight) {
       modalStyle = {height: calculatedHeight.height};
+    }
+
+    let useScrollbar = false;
+    if (this.props.useGemini && calculatedHeight.height !== 'auto') {
+      useScrollbar = true;
     }
 
     return (
@@ -296,7 +301,7 @@ class ModalContents extends Util.mixin(BindMixin) {
           {this.getHeader()}
           <div className={props.bodyClass} style={modalStyle}>
             <div ref="innerContainer" className={props.innerBodyClass}>
-              {this.getModalContent(this.props.useGemini, contentHeight)}
+              {this.getModalContent(useScrollbar, contentHeight)}
             </div>
           </div>
           {this.getFooter()}
@@ -339,8 +344,8 @@ class ModalContents extends Util.mixin(BindMixin) {
 }
 
 ModalContents.defaultProps = {
-  dynamicHeight: true,
   closeByBackdropClick: true,
+  dynamicHeight: true,
   footer: null,
   maxHeightPercentage: 0.6,
   onClose: () => {},
@@ -372,11 +377,11 @@ ModalContents.defaultProps = {
 };
 
 ModalContents.propTypes = {
-  // Allow resize of modal to fit screen. Defaults to true.
-  dynamicHeight: PropTypes.bool,
   children: PropTypes.node,
   // Allow closing of modal when click happens outside modal. Defaults to true.
   closeByBackdropClick: PropTypes.bool,
+  // Allow resize of modal to fit screen. Defaults to true.
+  dynamicHeight: PropTypes.bool,
   // Optional footer
   footer: PropTypes.object,
   // Maximum percent of the viewport the modal can be. Defaults to 0.5.

--- a/src/Modal/ModalContents.js
+++ b/src/Modal/ModalContents.js
@@ -286,9 +286,13 @@ class ModalContents extends Util.mixin(BindMixin) {
     let contentHeight = calculatedHeight.contentHeight;
     let modalStyle = {height: calculatedHeight.height};
 
-    let useScrollbar = false;
-    if (calculatedHeight.height !== 'auto') {
-      useScrollbar = true;
+    let useScrollbar = this.props.useScrollbar;
+    if (useScrollbar === null) {
+      if (calculatedHeight.height !== 'auto') {
+        useScrollbar = true;
+      } else {
+        useScrollbar = false;
+      }
     }
 
     return (
@@ -353,6 +357,7 @@ ModalContents.defaultProps = {
   titleText: '',
   transitionNameBackdrop: 'modal-backdrop',
   transitionNameModal: 'modal',
+  useScrollbar: null,
 
   // Default classes.
   backdropClass: 'modal-backdrop',
@@ -397,6 +402,8 @@ ModalContents.propTypes = {
   transitionNameBackdrop: PropTypes.string,
   // Optional enter and leave transition name for modal
   transitionNameModal: PropTypes.string,
+  // Optionally disable scrollbar to allow overflow (such as a dropdown).
+  useScrollbar: PropTypes.bool,
 
   // Classes
   backdropClass: PropTypes.string,

--- a/src/Modal/__tests__/ModalContents-test.js
+++ b/src/Modal/__tests__/ModalContents-test.js
@@ -33,6 +33,67 @@ describe('ModalContents', function () {
       var modal = instance.getModal();
       expect(TestUtils.isElement(modal)).toEqual(true);
     });
+
+    it('should not call for scrollbar when useGemini prop set to false',
+      function () {
+        var instance = TestUtils.renderIntoDocument(
+          <ModalContents
+            open={true}
+            useGemini={false} />
+        );
+        instance.getModalContent = jasmine.createSpy();
+        instance.getModal();
+
+        expect(instance.getModalContent.mostRecentCall.args[0]).toEqual(false);
+      }
+    );
+
+    it('should use scrollbar if scrollbar enabled and height not auto',
+      function () {
+        var instance = TestUtils.renderIntoDocument(
+          <ModalContents
+            open={true}
+            useGemini={true} />
+        );
+        instance.getModalContent = jasmine.createSpy();
+        instance.heightInfo.height = '63px';
+        instance.getModal();
+
+        expect(instance.getModalContent).toHaveBeenCalledWith(true, 'auto');
+      }
+    );
+
+    it('should not use scrollbar if height is auto, even if scrollbar enabled',
+      function () {
+        var instance = TestUtils.renderIntoDocument(
+          <ModalContents
+            open={true}
+            useGemini={true} />
+        );
+        instance.getModalContent = jasmine.createSpy();
+        instance.heightInfo.height = 'auto';
+        instance.getModal();
+
+        expect(instance.getModalContent).toHaveBeenCalledWith(false, 'auto');
+      }
+    );
+
+    it('should dynamically set height if dynamicHeight prop is true',
+      function () {
+        ModalContents.prototype.resetHeight = function () {
+          this.heightInfo = {height: 63}
+        };
+        var instance = TestUtils.renderIntoDocument(
+          <ModalContents
+            bodyClass={'target'}
+            open={true}
+            dynamicHeight={true} />
+        );
+        var modal = TestUtils.findRenderedDOMComponentWithClass(instance, 'target');
+
+        expect(modal.props.style).toEqual({height: 63});
+      }
+    );
   });
 
   describe('#onClose', function () {


### PR DESCRIPTION
Changes to Modal: allow disabling of gemini scrollbar and allow disabling of dynamic height adjustment. Disabling scrollbar allows for components to overflow the modal (such as dropdown).


```
<Modal
  dynamicHeight={false}
  useGemini={false}
  ... >
```
![](http://cl.ly/0q2n44172c0R/Screen%20Recording%202016-01-19%20at%2005.15%20PM.gif)