### PR TITLE
Add eventType to eventObject that gets passed to onChange handler

### DIFF
--- a/src/Form/Form.js
+++ b/src/Form/Form.js
@@ -71,7 +71,7 @@ class Form extends Util.mixin(BindMixin) {
   }
 
   handleEvent(eventType, fieldName, fieldValue, event) {
-    let eventObj = {fieldName, fieldValue, event};
+    let eventObj = {eventType, fieldName, fieldValue, event};
 
     switch (eventType) {
       case 'blur':


### PR DESCRIPTION
The `eventType` (blur, focus, change) needs to be passed back to the `onChange` handler.