### PR TITLE
At super small widths, have the width property apply to all modals

### DIFF
--- a/src/Modal/modal.less
+++ b/src/Modal/modal.less
@@ -121,7 +121,7 @@
 
 & when (@screen-mini-enabled) {
   @media (min-width: @screen-mini) {
-    .modal.modal-large {
+    .modal {
       width: 500px;
     }
   }


### PR DESCRIPTION
This was causing the `Confirm` modal (which doesn't have `.modal-large` to have weird widths at small screen sizes