### PR TITLE
Fix side panel scroll

### DIFF
--- a/docs/src/Table/index.js
+++ b/docs/src/Table/index.js
@@ -480,6 +480,7 @@ class TableExample extends React.Component {
                 </div>
                 <GeminiScrollbar
                   autoshow={true}
+                  className="container-scrollable"
                   style={{height: 800}}>
                   <Table
                     className="table"

--- a/src/SidePanel/SidePanelContents.js
+++ b/src/SidePanel/SidePanelContents.js
@@ -150,7 +150,7 @@ SidePanelContents.defaultProps = {
 
   // Classes
   backdropClass: 'side-panel-backdrop',
-  bodyClass: 'side-panel-content',
+  bodyClass: 'side-panel-content container-scrollable',
   containerClass: 'side-panel-container',
   headerClass: 'side-panel-header',
   headerContainerClass: 'side-panel-header-container container container-fluid container-fluid-narrow container-pod container-pod-short',

--- a/src/overrides/gemini-scrollbar.less
+++ b/src/overrides/gemini-scrollbar.less
@@ -64,7 +64,7 @@
 }
 
 .container-scrollable {
-  flex: 8;
+  flex: 1;
   overflow: auto;
   > .gm-scrollbar-container {
     height: 100%;


### PR DESCRIPTION
This fixes a problem with the side panel, where the contents wouldn't scroll when Mac OSX scrollbar setting was set to: "Automatically based on mouse or trackpad" and a mouse or external trackpad is used.