### PR TITLE
Remove cursor type override

### DIFF
--- a/src/Table/table.less
+++ b/src/Table/table.less
@@ -5,7 +5,6 @@
 
 .table {
   th {
-    cursor: default;
     outline: none;
     user-select: none;
   }


### PR DESCRIPTION
Removing cursor type style to allow elements within table to set their own cursor types.