### PR TITLE
Improve tooltip.

### DIFF
--- a/docs/src/Tooltip/index.js
+++ b/docs/src/Tooltip/index.js
@@ -58,22 +58,22 @@ class ToolTipExample extends React.Component {
               <section className="row canvas-pod">
                 <div className="column-12 column-mini-12">
                   <div className="button-collection">
-                    <Tooltip content="I'm a tooltip!" nodeType="button"
+                    <Tooltip content="I'm a tooltip!" elementTag="button"
                       wrapperClassName="tooltip-wrapper text-align-center
                       button">
                       Top
                     </Tooltip>
-                    <Tooltip content="I'm a tooltip!" nodeType="button"
+                    <Tooltip content="I'm a tooltip!" elementTag="button"
                       position="bottom" wrapperClassName="tooltip-wrapper
                       text-align-center button">
                       Bottom
                     </Tooltip>
-                    <Tooltip content="I'm a tooltip!" nodeType="button"
+                    <Tooltip content="I'm a tooltip!" elementTag="button"
                       position="left" wrapperClassName="tooltip-wrapper
                       text-align-center button">
                       Left
                     </Tooltip>
-                    <Tooltip content="I'm a tooltip!" nodeType="button"
+                    <Tooltip content="I'm a tooltip!" elementTag="button"
                       position="right" wrapperClassName="tooltip-wrapper
                       text-align-center button">
                       Right

--- a/docs/src/Tooltip/index.js
+++ b/docs/src/Tooltip/index.js
@@ -57,18 +57,28 @@ class ToolTipExample extends React.Component {
               </section>
               <section className="row canvas-pod">
                 <div className="column-12 column-mini-12">
-                  <Tooltip content="I'm a tooltip!">
-                    <button className="button">Top</button>
-                  </Tooltip>
-                  <Tooltip content="I'm a tooltip!" position="bottom">
-                    <button className="button">Bottom</button>
-                  </Tooltip>
-                  <Tooltip content="I'm a tooltip!" position="left">
-                    <button className="button">Left</button>
-                  </Tooltip>
-                  <Tooltip content="I'm a tooltip!" position="right">
-                    <button className="button">Right</button>
-                  </Tooltip>
+                  <div className="button-collection">
+                    <Tooltip content="I'm a tooltip!" nodeType="button"
+                      wrapperClassName="tooltip-wrapper text-align-center
+                      button">
+                      Top
+                    </Tooltip>
+                    <Tooltip content="I'm a tooltip!" nodeType="button"
+                      position="bottom" wrapperClassName="tooltip-wrapper
+                      text-align-center button">
+                      Bottom
+                    </Tooltip>
+                    <Tooltip content="I'm a tooltip!" nodeType="button"
+                      position="left" wrapperClassName="tooltip-wrapper
+                      text-align-center button">
+                      Left
+                    </Tooltip>
+                    <Tooltip content="I'm a tooltip!" nodeType="button"
+                      position="right" wrapperClassName="tooltip-wrapper
+                      text-align-center button">
+                      Right
+                    </Tooltip>
+                  </div>
                 </div>
               </section>
             </div>

--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -94,6 +94,9 @@ class Tooltip extends Util.mixin(BindMixin) {
     // the props.
     let anchor = state.anchor || props.anchor;
     let position = state.position || props.position;
+    let DOMNode = props.nodeType;
+    // Pass along any props that aren't specific to the Tooltip.
+    let nodeProps = Util.exclude(props, Object.keys(Tooltip.propTypes));
 
     let tooltipClasses = classnames(props.className, `anchor-${anchor}`,
       `position-${position}`, {
@@ -111,15 +114,16 @@ class Tooltip extends Util.mixin(BindMixin) {
     }
 
     return (
-      <div className={props.tooltipWrapperClassName}
+      <DOMNode className={props.wrapperClassName}
         onMouseEnter={this.handleMouseEnter}
-        onMouseLeave={this.handleMouseLeave}>
+        onMouseLeave={this.handleMouseLeave}
+        {...nodeProps}>
         {props.children}
         <div className={tooltipClasses} ref="tooltipContent"
           style={tooltipStyle}>
           {props.content}
         </div>
-      </div>
+      </DOMNode>
     );
   }
 }
@@ -127,8 +131,9 @@ class Tooltip extends Util.mixin(BindMixin) {
 Tooltip.defaultProps = {
   anchor: 'center',
   className: 'tooltip',
+  nodeType: 'div',
   position: 'top',
-  tooltipWrapperClassName: 'tooltip-wrapper text-align-center',
+  wrapperClassName: 'tooltip-wrapper text-align-center',
   wrapText: false
 };
 
@@ -143,11 +148,13 @@ Tooltip.propTypes = {
   className: React.PropTypes.string,
   // The tooltip's content.
   content: React.PropTypes.node.isRequired,
+  // The type of node rendered.
+  nodeType: React.PropTypes.string,
   // Position the tooltip on an edge of the tooltip trigger. Default is top.
   position: React.PropTypes.oneOf(['top', 'bottom', 'right', 'left']),
-  tooltipWrapperClassName: React.PropTypes.string,
   // Explicitly set the width of the tooltip. Default is auto.
   width: React.PropTypes.number,
+  wrapperClassName: React.PropTypes.string,
   // Allow the text content to wrap. Default is false. This should be used with
   // the width property, because otherwise the width of the content will be the
   // same as the trigger.

--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -94,7 +94,6 @@ class Tooltip extends Util.mixin(BindMixin) {
     // the props.
     let anchor = state.anchor || props.anchor;
     let position = state.position || props.position;
-    let DOMNode = props.nodeType;
     // Pass along any props that aren't specific to the Tooltip.
     let nodeProps = Util.exclude(props, Object.keys(Tooltip.propTypes));
 
@@ -114,7 +113,7 @@ class Tooltip extends Util.mixin(BindMixin) {
     }
 
     return (
-      <DOMNode className={props.wrapperClassName}
+      <props.elementTag className={props.wrapperClassName}
         onMouseEnter={this.handleMouseEnter}
         onMouseLeave={this.handleMouseLeave}
         {...nodeProps}>
@@ -123,7 +122,7 @@ class Tooltip extends Util.mixin(BindMixin) {
           style={tooltipStyle}>
           {props.content}
         </div>
-      </DOMNode>
+      </props.elementTag>
     );
   }
 }
@@ -131,7 +130,7 @@ class Tooltip extends Util.mixin(BindMixin) {
 Tooltip.defaultProps = {
   anchor: 'center',
   className: 'tooltip',
-  nodeType: 'div',
+  elementTag: 'div',
   position: 'top',
   wrapperClassName: 'tooltip-wrapper text-align-center',
   wrapText: false
@@ -149,7 +148,7 @@ Tooltip.propTypes = {
   // The tooltip's content.
   content: React.PropTypes.node.isRequired,
   // The type of node rendered.
-  nodeType: React.PropTypes.string,
+  elementTag: React.PropTypes.string,
   // Position the tooltip on an edge of the tooltip trigger. Default is top.
   position: React.PropTypes.oneOf(['top', 'bottom', 'right', 'left']),
   // Explicitly set the width of the tooltip. Default is auto.

--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -99,6 +99,7 @@ class Tooltip extends Util.mixin(BindMixin) {
 
     let tooltipClasses = classnames(props.className, `anchor-${anchor}`,
       `position-${position}`, {
+        'is-interactive': props.interactive,
         'is-open': state.isOpen,
         'wrap-text': props.wrapText
       }
@@ -131,6 +132,7 @@ Tooltip.defaultProps = {
   anchor: 'center',
   className: 'tooltip',
   elementTag: 'div',
+  interactive: false,
   position: 'top',
   wrapperClassName: 'tooltip-wrapper text-align-center',
   wrapText: false
@@ -149,6 +151,8 @@ Tooltip.propTypes = {
   content: React.PropTypes.node.isRequired,
   // The type of node rendered.
   elementTag: React.PropTypes.string,
+  // Allows user interaction on tooltips.
+  interactive: React.PropTypes.bool,
   // Position the tooltip on an edge of the tooltip trigger. Default is top.
   position: React.PropTypes.oneOf(['top', 'bottom', 'right', 'left']),
   // Explicitly set the width of the tooltip. Default is auto.

--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -95,7 +95,7 @@ class Tooltip extends Util.mixin(BindMixin) {
     let anchor = state.anchor || props.anchor;
     let position = state.position || props.position;
     // Pass along any props that aren't specific to the Tooltip.
-    let nodeProps = Util.exclude(props, Object.keys(Tooltip.propTypes));
+    let elementProps = Util.exclude(props, Object.keys(Tooltip.propTypes));
 
     let tooltipClasses = classnames(props.className, `anchor-${anchor}`,
       `position-${position}`, {
@@ -116,7 +116,7 @@ class Tooltip extends Util.mixin(BindMixin) {
       <props.elementTag className={props.wrapperClassName}
         onMouseEnter={this.handleMouseEnter}
         onMouseLeave={this.handleMouseLeave}
-        {...nodeProps}>
+        {...elementProps}>
         {props.children}
         <div className={tooltipClasses} ref="tooltipContent"
           style={tooltipStyle}>

--- a/src/Tooltip/tooltip.less
+++ b/src/Tooltip/tooltip.less
@@ -27,6 +27,7 @@
   line-height: @tooltip-line-height;
   opacity: 0;
   padding: @tooltip-padding-vertical @tooltip-padding-horizontal;
+  pointer-events: none;
   position: absolute;
   transition: opacity 0.3s, visibility 0.3s;
   visibility: hidden;
@@ -43,6 +44,10 @@
 
   &.wrap-text {
     white-space: normal;
+  }
+
+  &.is-interactive {
+    pointer-events: auto;
   }
 
   &.is-open {

--- a/src/Tooltip/tooltip.less
+++ b/src/Tooltip/tooltip.less
@@ -12,11 +12,10 @@
 @tooltip-arrow-border-width: 7px;
 @tooltip-arrow-offset: 8px;
 
-@tooltip-trigger-margin: @base-spacing-unit * 1/4;
+@tooltip-anchor-offset: @tooltip-arrow-offset + @tooltip-arrow-border-width;
 
 .tooltip-wrapper {
   display: inline-block;
-  margin-left: @tooltip-trigger-margin;
   position: relative;
 }
 
@@ -65,7 +64,7 @@
     }
 
     &.anchor-start {
-      left: @tooltip-arrow-offset * -1px;
+      left: calc(~"50% - @{tooltip-anchor-offset}");
 
       &:after {
         left: @tooltip-arrow-offset;
@@ -73,7 +72,7 @@
     }
 
     &.anchor-end {
-      right: @tooltip-arrow-offset * -1px;
+      right: calc(~"50% - @{tooltip-anchor-offset}");
 
       &:after {
         right: @tooltip-arrow-offset;
@@ -117,7 +116,7 @@
     }
 
     &.anchor-start {
-      top: @tooltip-arrow-offset * -1px;
+      top: calc(~"50% - @{tooltip-anchor-offset}");
 
       &:after {
         top: @tooltip-arrow-offset;
@@ -125,7 +124,7 @@
     }
 
     &.anchor-end {
-      bottom: @tooltip-arrow-offset * -1px;
+      bottom: calc(~"50% - @{tooltip-anchor-offset}");
 
       &:after {
         bottom: @tooltip-arrow-offset;


### PR DESCRIPTION
* Use of the `anchor` prop will now align the tooltip's arrow
at 50% of the width or height (depending on the `position`
prop), and the Tooltip's content will then be anchored
according to the prop definition.
* Allows custom DOM node to be used
* Pass all props that aren't specific to Tooltip to the node
* Remove specific margin styling