### PR TITLE
Allow form-row-element to be overridden

### DIFF
--- a/src/Form/FieldCheckbox.js
+++ b/src/Form/FieldCheckbox.js
@@ -54,8 +54,7 @@ class FieldCheckbox extends Util.mixin(BindMixin) {
   getRowClass(props) {
     return classNames(
       `column-${props.columnWidth}`,
-      'form-row-element',
-      'checkbox'
+      props.formElementClass
     );
   }
 
@@ -90,6 +89,7 @@ class FieldCheckbox extends Util.mixin(BindMixin) {
 
 FieldCheckbox.defaultProps = {
   columnWidth: 12,
+  formElementClass: 'form-row-element checkbox',
   handleEvent: function () {}
 };
 
@@ -109,6 +109,7 @@ FieldCheckbox.propTypes = {
   validationError: React.PropTypes.object,
 
   // Classes
+  formElementClass: React.PropTypes.string,
   formGroupClass: React.PropTypes.string,
   formGroupErrorClass: React.PropTypes.string,
   helpBlockClass: React.PropTypes.string,

--- a/src/Form/FieldCheckboxMultiple.js
+++ b/src/Form/FieldCheckboxMultiple.js
@@ -86,7 +86,7 @@ class FieldCheckboxMultiple extends Util.mixin(BindMixin) {
   getRowClass(props) {
     return classNames(
       `column-${props.columnWidth}`,
-      'form-row-element checkbox'
+      props.formElementClass
     );
   }
 
@@ -115,6 +115,7 @@ class FieldCheckboxMultiple extends Util.mixin(BindMixin) {
 
 FieldCheckboxMultiple.defaultProps = {
   columnWidth: 12,
+  formElementClass: 'form-row-element checkbox',
   handleEvent: function () {}
 };
 
@@ -137,6 +138,7 @@ FieldCheckboxMultiple.propTypes = {
   validationError: React.PropTypes.object,
 
   // Classes
+  formElementClass: React.PropTypes.string,
   formGroupClass: React.PropTypes.string,
   formGroupErrorClass: React.PropTypes.string,
   helpBlockClass: React.PropTypes.string,

--- a/src/Form/FieldInput.js
+++ b/src/Form/FieldInput.js
@@ -58,7 +58,7 @@ class FieldInput extends React.Component {
   getRowClass(props) {
     return classNames(
       `column-${props.columnWidth}`,
-      'form-row-element',
+      props.formElementClass,
       {
         'form-row-edit': this.isEditing(),
         'form-row-input': props.writeType === 'input',
@@ -169,6 +169,7 @@ class FieldInput extends React.Component {
 
 FieldInput.defaultProps = {
   columnWidth: 12,
+  formElementClass: 'form-row-element',
   handleEvent: function () {},
   value: '',
   writeType: 'input'
@@ -212,6 +213,7 @@ FieldInput.propTypes = {
   writeType: React.PropTypes.string,
 
   // Classes
+  formElementClass: React.PropTypes.string,
   formGroupClass: React.PropTypes.string,
   formGroupErrorClass: React.PropTypes.string,
   helpBlockClass: React.PropTypes.string,

--- a/src/Form/ItemCheckbox.js
+++ b/src/Form/ItemCheckbox.js
@@ -50,7 +50,7 @@ class ItemCheckbox extends Util.mixin(BindMixin) {
     }
 
     return (
-      <span className="form-element-checkbox-label">
+      <span className={this.props.checkboxLabelClass}>
         {label}
       </span>
     );
@@ -90,6 +90,7 @@ class ItemCheckbox extends Util.mixin(BindMixin) {
 }
 
 ItemCheckbox.defaultProps = {
+  checkboxLabelClass: 'form-element-checkbox-label',
   handleChange: function () {},
   labelClass: 'form-row-element form-element-checkbox'
 };
@@ -116,6 +117,7 @@ ItemCheckbox.propTypes = {
   name: React.PropTypes.string.isRequired,
 
   // Classes
+  checkboxLabelClass: React.PropTypes.string,
   labelClass: React.PropTypes.string
 };
 

--- a/src/Form/ItemCheckbox.js
+++ b/src/Form/ItemCheckbox.js
@@ -60,7 +60,6 @@ class ItemCheckbox extends Util.mixin(BindMixin) {
     let {props} = this;
 
     let labelClass = classNames({
-      'form-row-element form-element-checkbox': true,
       'mute': props.disabled,
       [props.labelClass]: !!props.labelClass
     });
@@ -91,7 +90,8 @@ class ItemCheckbox extends Util.mixin(BindMixin) {
 }
 
 ItemCheckbox.defaultProps = {
-  handleChange: function () {}
+  handleChange: function () {},
+  labelClass: 'form-row-element form-element-checkbox'
 };
 
 ItemCheckbox.propTypes = {


### PR DESCRIPTION
All the classes are the same. There is just the ability to override classes you don't want now.

![px](http://cl.ly/0A151F2Y0f14/Image%202016-03-30%20at%202.35.02%20PM.png)