### PR TITLE
Allow columns to have custom value getters

### DIFF
--- a/src/Table/Table.js
+++ b/src/Table/Table.js
@@ -171,11 +171,20 @@ class Table extends React.Component {
     );
   }
 
+  getCellValue(row, prop, column) {
+    let {getValue} = column;
+    if (getValue && typeof getValue === 'function') {
+      return getValue(row, prop);
+    }
+
+    return row[prop];
+  }
+
   getRowCells(columns, sortBy, buildRowOptions, row, rowIndex) {
     let rowCells = columns.map((column, index) => {
       let cellClassName = getClassName(column, sortBy, row, columns);
       let prop = column.prop;
-      let cellValue = row[prop];
+      let cellValue = this.getCellValue(row, prop, column);
       let cellID;
 
       if (column.cacheCell === true) {


### PR DESCRIPTION
This is useful because if the data doesn't have the prop at the top level, using `row[prop]` won't work (for example, you'd have to go inside a `resources` object to retrieve the value like so: `row.resources[prop]`.