### PR TITLE
Use Portal for Tooltip

### DIFF
--- a/docs/src/Tooltip/index.js
+++ b/docs/src/Tooltip/index.js
@@ -39,6 +39,8 @@ class ToolTipExample extends React.Component {
   // when the mouse leaves the trigger. When true, the mouse is allowed to enter
   // the tooltip. Default is false.
   interactive: React.PropTypes.bool,
+  maxWidth: React.PropTypes.oneOf([React.PropTypes.number,
+    React.PropTypes.string]),
   // Position the tooltip on an edge of the tooltip trigger. Default is top.
   position: React.PropTypes.oneOf(['top', 'bottom', 'right', 'left']),
   // Explicitly set the width of the tooltip. Default is auto.

--- a/docs/src/Tooltip/index.js
+++ b/docs/src/Tooltip/index.js
@@ -33,11 +33,17 @@ class ToolTipExample extends React.Component {
   className: React.PropTypes.string,
   // The tooltip's content.
   content: React.PropTypes.node.isRequired,
+  // The type of node rendered.
+  elementTag: React.PropTypes.string,
+  // Allows user interaction on tooltips. When false, the tooltip is dismissed
+  // when the mouse leaves the trigger. When true, the mouse is allowed to enter
+  // the tooltip. Default is false.
+  interactive: React.PropTypes.bool,
   // Position the tooltip on an edge of the tooltip trigger. Default is top.
   position: React.PropTypes.oneOf(['top', 'bottom', 'right', 'left']),
-  tooltipWrapperClassName: React.PropTypes.string,
   // Explicitly set the width of the tooltip. Default is auto.
   width: React.PropTypes.number,
+  wrapperClassName: React.PropTypes.string,
   // Allow the text content to wrap. Default is false. This should be used with
   // the width property, because otherwise the width of the content will be the
   // same as the trigger.

--- a/docs/src/Tooltip/index.js
+++ b/docs/src/Tooltip/index.js
@@ -5,6 +5,22 @@ import Tooltip from '../../../src/Tooltip/Tooltip.js';
 
 class ToolTipExample extends React.Component {
   render() {
+    let tooltipContent = (
+      <p className="text-color-white small flush-bottom">
+        This tooltip is not interactive.
+      </p>
+    );
+    let interactiveTooltipContent = (
+      <div>
+        <p className="text-color-white small">
+          This tooltip is interactive, so the user is able to interact with its contents.
+        </p>
+        <p className="text-color-white small flush-bottom">
+          Example: <a href="#">Back to Top</a>.
+        </p>
+      </div>
+    );
+
     return (
       <div className="row canvas-pod">
         <div>
@@ -39,16 +55,18 @@ class ToolTipExample extends React.Component {
   // when the mouse leaves the trigger. When true, the mouse is allowed to enter
   // the tooltip. Default is false.
   interactive: React.PropTypes.bool,
-  maxWidth: React.PropTypes.oneOf([React.PropTypes.number,
+  maxWidth: React.PropTypes.oneOfType([React.PropTypes.number,
     React.PropTypes.string]),
   // Position the tooltip on an edge of the tooltip trigger. Default is top.
   position: React.PropTypes.oneOf(['top', 'bottom', 'right', 'left']),
+  // The nearest scrolling DOMNode that contains the tooltip. Default is window.
+  // Also accepts a string, which will be treated as a selector for the node.
+  scrollContainer: React.PropTypes.oneOfType([React.PropTypes.object,
+    React.PropTypes.string]),
   // Explicitly set the width of the tooltip. Default is auto.
   width: React.PropTypes.number,
   wrapperClassName: React.PropTypes.string,
-  // Allow the text content to wrap. Default is false. This should be used with
-  // the width property, because otherwise the width of the content will be the
-  // same as the trigger.
+  // Allow the text content to wrap. Default is true.
   wrapText: React.PropTypes.bool
 };`}
             </pre>
@@ -66,22 +84,24 @@ class ToolTipExample extends React.Component {
               <section className="row canvas-pod">
                 <div className="column-12 column-mini-12">
                   <div className="button-collection">
-                    <Tooltip content="I'm a tooltip!" elementTag="button"
+                    <Tooltip content={tooltipContent} elementTag="button"
                       wrapperClassName="tooltip-wrapper text-align-center
                       button">
                       Top
                     </Tooltip>
-                    <Tooltip content="I'm a tooltip!" elementTag="button"
+                    <Tooltip content={tooltipContent} elementTag="button"
                       position="bottom" wrapperClassName="tooltip-wrapper
                       text-align-center button">
                       Bottom
                     </Tooltip>
-                    <Tooltip content="I'm a tooltip!" elementTag="button"
+                    <Tooltip content={interactiveTooltipContent}
+                      elementTag="button" interactive={true} maxWidth={225}
                       position="left" wrapperClassName="tooltip-wrapper
                       text-align-center button">
                       Left
                     </Tooltip>
-                    <Tooltip content="I'm a tooltip!" elementTag="button"
+                    <Tooltip content={interactiveTooltipContent}
+                      elementTag="button" interactive={true} maxWidth={225}
                       position="right" wrapperClassName="tooltip-wrapper
                       text-align-center button">
                       Right
@@ -98,27 +118,49 @@ import React from 'react';
 
 class FormExample extends React.Component {
   render() {
+    let tooltipContent = (
+      <p className="text-color-white small flush-bottom">
+        This tooltip is not interactive.
+      </p>
+    );
+    let interactiveTooltipContent = (
+      <div>
+        <p className="text-color-white small">
+          This tooltip is interactive, so the user is able to interact with its contents.
+        </p>
+        <p className="text-color-white small flush-bottom">
+          Example: <a href="#">Back to Top</a>.
+        </p>
+      </div>
+    );
+
     return (
       <section className="row canvas-pod">
-        <div className="column-6 column-mini-3">
-          <Tooltip content="I'm a tooltip!">
-            <button className="button">Top</button>
-          </Tooltip>
-        </div>
-        <div className="column-6 column-mini-3">
-          <Tooltip content="I'm a tooltip!" position="right">
-            <button className="button">Right</button>
-          </Tooltip>
-        </div>
-        <div className="column-6 column-mini-3">
-          <Tooltip content="I'm a tooltip!" position="bottom">
-            <button className="button">Bottom</button>
-          </Tooltip>
-        </div>
-        <div className="column-6 column-mini-3">
-          <Tooltip content="I'm a tooltip!" position="left">
-            <button className="button">Left</button>
-          </Tooltip>
+        <div className="column-12 column-mini-12">
+          <div className="button-collection">
+            <Tooltip content={tooltipContent} elementTag="button"
+              wrapperClassName="tooltip-wrapper text-align-center
+              button">
+              Top
+            </Tooltip>
+            <Tooltip content={tooltipContent} elementTag="button"
+              position="bottom" wrapperClassName="tooltip-wrapper
+              text-align-center button">
+              Bottom
+            </Tooltip>
+            <Tooltip content={interactiveTooltipContent}
+              elementTag="button" interactive={true} maxWidth={225}
+              position="left" wrapperClassName="tooltip-wrapper
+              text-align-center button">
+              Left
+            </Tooltip>
+            <Tooltip content={interactiveTooltipContent}
+              elementTag="button" interactive={true} maxWidth={225}
+              position="right" wrapperClassName="tooltip-wrapper
+              text-align-center button">
+              Right
+            </Tooltip>
+          </div>
         </div>
       </section>
     );

--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -23,6 +23,7 @@ class Tooltip extends Util.mixin(BindMixin) {
 
   constructor() {
     super(...arguments);
+    this.container = null;
     this.state = {isOpen: false};
   }
 
@@ -53,7 +54,16 @@ class Tooltip extends Util.mixin(BindMixin) {
   }
 
   addScrollListener() {
-    this.props.scrollContainer.addEventListener('scroll', this.dismissTooltip);
+    if (!this.container) {
+      if (typeof this.props.scrollContainer === 'string') {
+        this.container = DOMUtil.closest(ReactDOM.findDOMNode(this),
+          this.props.scrollContainer) || window;
+      } else {
+        this.container = this.props.scrollContainer;
+      }
+    }
+
+    this.container.addEventListener('scroll', this.dismissTooltip);
   }
 
   dismissTooltip() {
@@ -139,8 +149,7 @@ class Tooltip extends Util.mixin(BindMixin) {
   }
 
   removeScrollListener() {
-    this.props.scrollContainer.removeEventListener('scroll',
-      this.dismissTooltip);
+    this.container.removeEventListener('scroll', this.dismissTooltip);
   }
 
   transformAnchor(anchor, clearanceStart, clearanceEnd, tooltipDimension,
@@ -253,12 +262,14 @@ Tooltip.propTypes = {
   // when the mouse leaves the trigger. When true, the mouse is allowed to enter
   // the tooltip. Default is false.
   interactive: React.PropTypes.bool,
-  maxWidth: React.PropTypes.oneOf([React.PropTypes.number,
+  maxWidth: React.PropTypes.oneOfType([React.PropTypes.number,
     React.PropTypes.string]),
   // Position the tooltip on an edge of the tooltip trigger. Default is top.
   position: React.PropTypes.oneOf(['top', 'bottom', 'right', 'left']),
   // The nearest scrolling DOMNode that contains the tooltip. Default is window.
-  scrollContainer: React.PropTypes.object,
+  // Also accepts a string, which will be treated as a selector for the node.
+  scrollContainer: React.PropTypes.oneOfType([React.PropTypes.object,
+    React.PropTypes.string]),
   // Explicitly set the width of the tooltip. Default is auto.
   width: React.PropTypes.number,
   wrapperClassName: React.PropTypes.string,

--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -193,7 +193,7 @@ class Tooltip extends Util.mixin(BindMixin) {
       `position-${position}`, {
         'is-interactive': props.interactive,
         'is-open': state.isOpen,
-        'wrap-text': props.wrapText
+        'no-wrap': !props.wrapText
       }
     );
 
@@ -206,6 +206,16 @@ class Tooltip extends Util.mixin(BindMixin) {
 
     if (props.width) {
       tooltipStyle.width = `${props.width}px`;
+    }
+
+    if (props.maxWidth) {
+      let maxWidth = props.maxWidth;
+
+      if (typeof props.maxWidth === 'number') {
+        maxWidth = `${maxWidth}px`;
+      }
+
+      tooltipStyle.maxWidth = maxWidth;
     }
 
     return (
@@ -237,7 +247,7 @@ Tooltip.defaultProps = {
   interactive: false,
   position: 'top',
   wrapperClassName: 'tooltip-wrapper text-align-center',
-  wrapText: false
+  wrapText: true
 };
 
 Tooltip.propTypes = {
@@ -253,16 +263,18 @@ Tooltip.propTypes = {
   content: React.PropTypes.node.isRequired,
   // The type of node rendered.
   elementTag: React.PropTypes.string,
-  // Allows user interaction on tooltips.
+  // Allows user interaction on tooltips. When false, the tooltip is dismissed
+  // when the mouse leaves the trigger. When true, the mouse is allowed to enter
+  // the tooltip. Default is false.
   interactive: React.PropTypes.bool,
+  maxWidth: React.PropTypes.oneOf([React.PropTypes.number,
+    React.PropTypes.string]),
   // Position the tooltip on an edge of the tooltip trigger. Default is top.
   position: React.PropTypes.oneOf(['top', 'bottom', 'right', 'left']),
   // Explicitly set the width of the tooltip. Default is auto.
   width: React.PropTypes.number,
   wrapperClassName: React.PropTypes.string,
-  // Allow the text content to wrap. Default is false. This should be used with
-  // the width property, because otherwise the width of the content will be the
-  // same as the trigger.
+  // Allow the text content to wrap. Default is true.
   wrapText: React.PropTypes.bool
 };
 

--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -44,6 +44,7 @@ class Tooltip extends Util.mixin(BindMixin) {
   handleTooltipMouseEnter() {
     if (this.props.interactive) {
       this.setState({isOpen: true});
+      this.addScrollListener();
     }
   }
 
@@ -195,17 +196,11 @@ class Tooltip extends Util.mixin(BindMixin) {
     }
 
     if (props.width) {
-      tooltipStyle.width = `${props.width}px`;
+      tooltipStyle.width = props.width;
     }
 
     if (props.maxWidth) {
-      let maxWidth = props.maxWidth;
-
-      if (typeof props.maxWidth === 'number') {
-        maxWidth = `${maxWidth}px`;
-      }
-
-      tooltipStyle.maxWidth = maxWidth;
+      tooltipStyle.maxWidth = props.maxWidth;
     }
 
     return (

--- a/src/Tooltip/__tests__/Tooltip-test.js
+++ b/src/Tooltip/__tests__/Tooltip-test.js
@@ -19,27 +19,18 @@ describe('Tooltip', function () {
   });
 
   it('should render with the intended class', function () {
-    var tooltip = TestUtils.scryRenderedDOMComponentsWithClass(
-      this.instance, 'foo'
-    );
-
-    expect(tooltip.length).toEqual(1);
+    expect(this.instance.refs.tooltipNode.classList.contains('foo'))
+      .toBeTruthy();
   });
 
   it('should render with the intended position as a class', function () {
-    var tooltip = TestUtils.scryRenderedDOMComponentsWithClass(
-      this.instance, 'position-bottom'
-    );
-
-    expect(tooltip.length).toEqual(1);
+    expect(this.instance.refs.tooltipNode.classList.contains('position-bottom'))
+      .toBeTruthy();
   });
 
   it('should render with the intended anchor as a class', function () {
-    var tooltip = TestUtils.scryRenderedDOMComponentsWithClass(
-      this.instance, 'anchor-start'
-    );
-
-    expect(tooltip.length).toEqual(1);
+    expect(this.instance.refs.tooltipNode.classList.contains('anchor-start'))
+      .toBeTruthy();
   });
 
   describe('#handleMouseEnter', function () {
@@ -51,15 +42,15 @@ describe('Tooltip', function () {
     });
 
     it('should set anchor to what was returned from #getIdealPosition',
-    function () {
-      this.instance.handleMouseEnter();
+      function () {
+      this.instance.handleMouseEnter('start', 'bottom');
 
       expect(this.instance.state.anchor).toEqual('start');
     });
 
     it('should set position to what was returned from #getIdealPosition',
-    function () {
-      this.instance.handleMouseEnter();
+      function () {
+      this.instance.handleMouseEnter('start', 'bottom');
 
       expect(this.instance.state.position).toEqual('bottom');
     });
@@ -68,7 +59,7 @@ describe('Tooltip', function () {
 
   describe('#handleMouseLeave', function () {
 
-    it('should set isOpen to true', function () {
+    it('should set isOpen to false', function () {
       this.instance.handleMouseLeave();
 
       expect(this.instance.state.isOpen).toBeFalsy();

--- a/src/Tooltip/tooltip.less
+++ b/src/Tooltip/tooltip.less
@@ -28,7 +28,7 @@
   opacity: 0;
   padding: @tooltip-padding-vertical @tooltip-padding-horizontal;
   pointer-events: none;
-  position: absolute;
+  position: fixed;
   transition: opacity 0.3s, visibility 0.3s;
   visibility: hidden;
   white-space: nowrap;
@@ -59,7 +59,6 @@
   &.position-top {
 
     &.anchor-center {
-      left: 50%;
       transform: translateX(-50%);
 
       &:after {
@@ -69,7 +68,7 @@
     }
 
     &.anchor-start {
-      left: calc(~"50% - @{tooltip-anchor-offset}");
+      transform: translateX(@tooltip-anchor-offset * -1);
 
       &:after {
         left: @tooltip-arrow-offset;
@@ -77,7 +76,7 @@
     }
 
     &.anchor-end {
-      right: calc(~"50% - @{tooltip-anchor-offset}");
+      transform: translateX(@tooltip-anchor-offset);
 
       &:after {
         right: @tooltip-arrow-offset;
@@ -86,7 +85,6 @@
   }
 
   &.position-bottom {
-    top: calc(~"100% + @{tooltip-arrow-border-width}");
 
     &:after {
       border-left-color: transparent;
@@ -97,7 +95,6 @@
   }
 
   &.position-top {
-    bottom: calc(~"100% + @{tooltip-arrow-border-width}");
 
     &:after {
       border-bottom: none;
@@ -121,7 +118,7 @@
     }
 
     &.anchor-start {
-      top: calc(~"50% - @{tooltip-anchor-offset}");
+      transform: translateY(@tooltip-anchor-offset * -1);
 
       &:after {
         top: @tooltip-arrow-offset;
@@ -129,7 +126,7 @@
     }
 
     &.anchor-end {
-      bottom: calc(~"50% - @{tooltip-anchor-offset}");
+      transform: translateY(calc(~"-100% + @{tooltip-anchor-offset}"));
 
       &:after {
         bottom: @tooltip-arrow-offset;
@@ -138,7 +135,6 @@
   }
 
   &.position-left {
-    right: calc(~"100% + @{tooltip-arrow-border-width}");
 
     &:after {
       border-bottom-color: transparent;
@@ -149,7 +145,6 @@
   }
 
   &.position-right {
-    left: calc(~"100% + @{tooltip-arrow-border-width}");
 
     &:after {
       border-bottom-color: transparent;

--- a/src/Tooltip/tooltip.less
+++ b/src/Tooltip/tooltip.less
@@ -20,13 +20,7 @@
 }
 
 .tooltip {
-  background: @tooltip-background;
-  border-radius: @tooltip-border-radius;
-  color: @tooltip-foreground;
-  font-size: @tooltip-font-size;
-  line-height: @tooltip-line-height;
   opacity: 0;
-  padding: @tooltip-padding-vertical @tooltip-padding-horizontal;
   pointer-events: none;
   position: fixed;
   transition: opacity 0.3s, visibility 0.3s;
@@ -34,12 +28,22 @@
   white-space: nowrap;
   z-index: 100;
 
-  &:after {
-    border-color: @tooltip-background;
-    border-style: solid;
-    border-width: @tooltip-arrow-border-width;
-    content: '';
-    position: absolute;
+  .tooltip-content {
+    background: @tooltip-background;
+    border-radius: @tooltip-border-radius;
+    color: @tooltip-foreground;
+    font-size: @tooltip-font-size;
+    line-height: @tooltip-line-height;
+    padding: @tooltip-padding-vertical @tooltip-padding-horizontal;
+    position: relative;
+
+    &:after {
+      border-color: @tooltip-background;
+      border-style: solid;
+      border-width: @tooltip-arrow-border-width;
+      content: '';
+      position: absolute;
+    }
   }
 
   &.wrap-text {
@@ -61,46 +65,63 @@
     &.anchor-center {
       transform: translateX(-50%);
 
-      &:after {
-        left: 50%;
-        transform: translateX(-50%);
+      .tooltip-content {
+
+        &:after {
+          left: 50%;
+          transform: translateX(-50%);
+        }
       }
     }
 
     &.anchor-start {
       transform: translateX(@tooltip-anchor-offset * -1);
 
-      &:after {
-        left: @tooltip-arrow-offset;
+      .tooltip-content {
+
+        &:after {
+          left: @tooltip-arrow-offset;
+        }
       }
     }
 
     &.anchor-end {
       transform: translateX(@tooltip-anchor-offset);
 
-      &:after {
-        right: @tooltip-arrow-offset;
+      .tooltip-content {
+
+        &:after {
+          right: @tooltip-arrow-offset;
+        }
       }
     }
   }
 
   &.position-bottom {
+    padding-top: @tooltip-arrow-border-width;
 
-    &:after {
-      border-left-color: transparent;
-      border-right-color: transparent;
-      border-top: none;
-      bottom: 100%;
+    .tooltip-content {
+
+      &:after {
+        border-left-color: transparent;
+        border-right-color: transparent;
+        border-top: none;
+        bottom: 100%;
+      }
     }
   }
 
   &.position-top {
+    padding-bottom: @tooltip-arrow-border-width;
 
-    &:after {
-      border-bottom: none;
-      border-left-color: transparent;
-      border-right-color: transparent;
-      top: 100%;
+    .tooltip-content {
+
+      &:after {
+        border-bottom: none;
+        border-left-color: transparent;
+        border-right-color: transparent;
+        top: 100%;
+      }
     }
   }
 
@@ -111,46 +132,63 @@
       top: 50%;
       transform: translateY(-50%);
 
-      &:after {
-        top: 50%;
-        transform: translateY(-50%);
+      .tooltip-content {
+
+        &:after {
+          top: 50%;
+          transform: translateY(-50%);
+        }
       }
     }
 
     &.anchor-start {
       transform: translateY(@tooltip-anchor-offset * -1);
 
-      &:after {
-        top: @tooltip-arrow-offset;
+      .tooltip-content {
+
+        &:after {
+          top: @tooltip-arrow-offset;
+        }
       }
     }
 
     &.anchor-end {
       transform: translateY(calc(~"-100% + @{tooltip-anchor-offset}"));
 
-      &:after {
-        bottom: @tooltip-arrow-offset;
+      .tooltip-content {
+
+        &:after {
+          bottom: @tooltip-arrow-offset;
+        }
       }
     }
   }
 
   &.position-left {
+    padding-right: @tooltip-arrow-border-width;
 
-    &:after {
-      border-bottom-color: transparent;
-      border-right: none;
-      border-top-color: transparent;
-      left: 100%;
+    .tooltip-content {
+
+      &:after {
+        border-bottom-color: transparent;
+        border-right: none;
+        border-top-color: transparent;
+        left: 100%;
+      }
     }
   }
 
   &.position-right {
+    padding-left: @tooltip-arrow-border-width;
 
-    &:after {
-      border-bottom-color: transparent;
-      border-left: none;
-      border-top-color: transparent;
-      right: 100%;
+    .tooltip-content {
+
+      &:after {
+        border-bottom-color: transparent;
+        border-left: none;
+        border-top-color: transparent;
+        right: 100%;
+      }
     }
   }
 

--- a/src/Tooltip/tooltip.less
+++ b/src/Tooltip/tooltip.less
@@ -20,13 +20,13 @@
 }
 
 .tooltip {
+  max-width: 600px;
   opacity: 0;
   pointer-events: none;
   position: fixed;
   transition: opacity 0.3s, visibility 0.3s;
   visibility: hidden;
-  white-space: nowrap;
-  z-index: 100;
+  z-index: 9999;
 
   .tooltip-content {
     background: @tooltip-background;
@@ -46,8 +46,8 @@
     }
   }
 
-  &.wrap-text {
-    white-space: normal;
+  &.no-wrap {
+    white-space: nowrap;
   }
 
   &.is-interactive {
@@ -86,7 +86,7 @@
     }
 
     &.anchor-end {
-      transform: translateX(@tooltip-anchor-offset);
+      transform: translateX(calc(~"-100% + @{tooltip-anchor-offset}"));
 
       .tooltip-content {
 

--- a/src/Util/DOMUtil.js
+++ b/src/Util/DOMUtil.js
@@ -84,6 +84,20 @@ const DOMUtil = {
     };
   },
 
+  getNodeClearance(DOMNode) {
+    let viewportHeight = DOMUtil.getViewportHeight();
+    let viewportWidth = DOMUtil.getViewportWidth();
+    let boundingRect = DOMNode.getBoundingClientRect();
+
+    return {
+      bottom: viewportHeight - boundingRect.bottom,
+      left: boundingRect.left,
+      right: viewportWidth - boundingRect.right,
+      top: boundingRect.top,
+      boundingRect
+    };
+  },
+
   getViewportHeight() {
     return Math.max(
       document.documentElement.clientHeight || 0,


### PR DESCRIPTION
This uses the portal and will work everywhere (even inside a container with `overflow: scroll`). That introduced a fair amount of additional logic to determine the position of the tooltip trigger and the ideal location for the tooltip content.