### PR TITLE
Fix Util.sortBy to not mutate collection

### DIFF
--- a/src/Util/Util.js
+++ b/src/Util/Util.js
@@ -435,9 +435,9 @@ var isArray = function (arg) {
 
 function sortBy(collection, sortProp) {
   if (isFunction(sortProp)) {
-    return collection.sort(sortProp);
+    return collection.slice().sort(sortProp);
   } else {
-    return collection.sort((a, b) => {
+    return collection.slice().sort((a, b) => {
       let keyA = a[sortProp],
         keyB = b[sortProp];
       if (keyA < keyB) {

--- a/src/Util/__tests__/Util-test.js
+++ b/src/Util/__tests__/Util-test.js
@@ -147,4 +147,38 @@ describe('Util', function () {
         .toEqual(capitalizedString);
     });
   });
+
+  describe('#sortBy', function () {
+
+    beforeEach(function () {
+      this.collection =
+        [{name: 'c', value: 1}, {name: 't', value: 3}, {name: 'a', value: 3}];
+    });
+
+    it('should not mutate original collection', function () {
+      let result = Util.sortBy(this.collection, 'value');
+
+      expect(result !== this.collection).toBeTruthy();
+    });
+
+    it('should sort collection by prop', function () {
+      let result = Util.sortBy(this.collection, 'name');
+
+      expect(result).toEqual(
+        [{name: 'a', value: 3}, {name: 'c', value: 1}, {name: 't', value: 3}]
+      );
+    });
+
+    it('should use custom compare function', function () {
+      let result = Util.sortBy(this.collection, function (a, b) {
+        var delta = a.value - b.value;
+        return delta / Math.abs(delta || 0);
+      });
+
+      expect(result).toEqual(
+        [{name: 'c', value: 1}, {name: 't', value: 3}, {name: 'a', value: 3}]
+      );
+    });
+
+  });
 });


### PR DESCRIPTION
Create copy of collection before sorting it to not mutate the original collection. Added test to verify correct behaviour.

/closes #239