### PR TITLE
Remove onKeyDownHandler on Textareas

### DIFF
--- a/src/Form/FieldTextarea.js
+++ b/src/Form/FieldTextarea.js
@@ -19,7 +19,6 @@ module.exports = class FieldTextarea extends FieldInput {
         <textarea
           ref="inputElement"
           className={classes}
-          onKeyDown={this.handleKeyDown.bind(this)}
           {...attributes}
           value={attributes.startValue} />
       );


### PR DESCRIPTION
Textareas are multiline input fields which should not be blured
if the `Enter` key is pressed.

As an example of the problem please take a look at the message text area at http://mesosphere.github.io/reactjs-components/#form