### PR TITLE
Fix missing gemini scrollbar import

### DIFF
--- a/docs/src/index.less
+++ b/docs/src/index.less
@@ -5,7 +5,7 @@
 @import "../styles/page-header.less";
 
 // Import all styles for all components
-@import (inline) "../../node_modules/react-gemini-scrollbar/node_modules/gemini-scrollbar/gemini-scrollbar.css";
+@import (inline) "../../node_modules/gemini-scrollbar/gemini-scrollbar.css";
 @import "../../src/overrides/gemini-scrollbar.less";
 
 @import "../../src/Dropdown/dropdown.less";

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "engines": {
     "node": "^4.x.x",
-    "npm": "^2.x.x"
+    "npm": "^3.x.x"
   },
   "repository": {
     "type": "git",

--- a/src/index.less
+++ b/src/index.less
@@ -1,4 +1,4 @@
-@import (inline) "../../node_modules/react-gemini-scrollbar/gemini-scrollbar/gemini-scrollbar.css";
+@import (inline) "../node_modules/gemini-scrollbar/gemini-scrollbar.css";
 @import "./overrides/gemini-scrollbar.less";
 
 @import "./Dropdown/dropdown.less";


### PR DESCRIPTION
it seems like we depended on `react-gemini-scrollbar` to ship with its own `node_modules` which isn't the case anymore. I did a fresh `npm install` and I get the following:
```
 ✘  ~/Development/reactjs-components   master ●  npm run livereload

> reactjs-components@0.14.0-beta.18 livereload /Users/pierlo/Development/reactjs-components
> NODE_ENV='development' ./node_modules/.bin/gulp docs:livereload

[13:56:35] Using gulpfile ~/Development/reactjs-components/gulpfile.js
[13:56:35] Starting 'docs:webpack'...
[13:56:35] Starting 'docs:eslint'...
[13:56:35] Starting 'docs:less'...
[13:56:35] Starting 'docs:html'...
[13:56:35] Starting 'docs:browsersync'...
[13:56:35] Finished 'docs:browsersync' after 20 ms
[13:56:35] Starting 'docs:watch'...
[13:56:35] Finished 'docs:watch' after 21 ms
[13:56:36] { [Error: '../../node_modules/react-gemini-scrollbar/node_modules/gemini-scrollbar/gemini-scrollbar.css' wasn't found. Tried - /Users/pierlo/Development/reactjs-components/node_modules/react-gemini-scrollbar/node_modules/gemini-scrollbar/gemini-scrollbar.css,../../node_modules/react-gemini-scrollbar/node_modules/gemini-scrollbar/gemini-scrollbar.css,../../node_modules/react-gemini-scrollbar/node_modules/gemini-scrollbar/gemini-scrollbar.css in file /Users/pierlo/Development/reactjs-components/docs/src/index.less line no. 8]
  type: 'File',
  filename: '/Users/pierlo/Development/reactjs-components/docs/src/index.less',
  index: 250,
  line: 8,
  callLine: NaN,
  callExtract: undefined,
  column: 0,
  extract:
   [ '// Import all styles for all components',
     '@import (inline) "../../node_modules/react-gemini-scrollbar/node_modules/gemini-scrollbar/gemini-scrollbar.css";',
     '@import "../../src/overrides/gemini-scrollbar.less";' ],
  message: '\'../../node_modules/react-gemini-scrollbar/node_modules/gemini-scrollbar/gemini-scrollbar.css\' wasn\'t found. Tried - /Users/pierlo/Development/reactjs-components/node_modules/react-gemini-scrollbar/node_modules/gemini-scrollbar/gemini-scrollbar.css,../../node_modules/react-gemini-scrollbar/node_modules/gemini-scrollbar/gemini-scrollbar.css,../../node_modules/react-gemini-scrollbar/node_modules/gemini-scrollbar/gemini-scrollbar.css in file /Users/pierlo/Development/reactjs-components/docs/src/index.less line no. 8',
  stack: undefined,
  lineNumber: 8,
  fileName: '/Users/pierlo/Development/reactjs-components/docs/src/index.less',
  name: 'Error',
  showStack: false,
  showProperties: true,
  plugin: 'gulp-less',
  __safety: { toString: [Function: bound ] } }
[13:56:36] Finished 'docs:less' after 431 ms
```

Or maybe it has to do with the new `npm 3` way of doing things? Not sure, either way this seems like a reasonable fix to my 👀 