### PR TITLE
Add support for focused option for input fields

### DIFF
--- a/docs/src/Form/index.js
+++ b/docs/src/Form/index.js
@@ -17,9 +17,11 @@ class FormExample extends React.Component {
         },
         {
           fieldType: 'text',
+          focused: true,
           name: 'uid',
           placeholder: 'Last name',
           required: true,
+          value: 'Last name',
           writeType: 'input'
         }
       ],
@@ -212,9 +214,11 @@ class FormExample extends React.Component {
         },
         {
           fieldType: 'text',
+          focused: true,
           name: 'uid',
           placeholder: 'Last name',
           required: true,
+          value: 'Last name',
           writeType: 'input'
         }
       ],

--- a/src/Form/FieldInput.js
+++ b/src/Form/FieldInput.js
@@ -17,6 +17,20 @@ class FieldInput extends React.Component {
     }
   }
 
+  componentDidMount() {
+    let inputElement = ReactDOM.findDOMNode(this.refs.inputElement);
+    if (inputElement != null &&
+        inputElement.type === 'text' &&
+        this.props.focused) {
+      // Don't interfere with existing transitions
+      setTimeout(function () {
+        var valueLength = inputElement.value.length;
+        inputElement.focus();
+        inputElement.setSelectionRange(valueLength, valueLength);
+      }, 0);
+    }
+  }
+
   bindEvents(attributes) {
     EVENTS.forEach((event) => {
       let htmlEvent = `on${Util.capitalize(event)}`;
@@ -181,6 +195,10 @@ FieldInput.propTypes = {
   // Optional. Which field property is currently being edited
   // (usually passed down from form definition)
   editing: React.PropTypes.string,
+  // Optional. Specify if the field should be focused
+  // Useful in combination with preset values, will set cursor to end of input
+  // (usually passed down from form definition)
+  focused: React.PropTypes.bool,
   // Function to handle when form is submitted
   // (usually passed down from form definition)
   handleSubmit: React.PropTypes.func,

--- a/src/Form/__tests__/FieldInput-test.js
+++ b/src/Form/__tests__/FieldInput-test.js
@@ -4,6 +4,7 @@ jest.dontMock('../../Util/KeyboardUtil');
 
 /* eslint-disable no-unused-vars */
 var React = require('react');
+var ReactDOM = require('react-dom');
 /* eslint-enable no-unused-vars */
 var TestUtils = require('react-addons-test-utils');
 
@@ -143,6 +144,26 @@ describe('FieldInput', function () {
       );
 
       expect(instance.getInputElement({}).type).toEqual('input');
+    });
+
+    it('should have the right selectionStart if focused', function () {
+      var instance = TestUtils.renderIntoDocument(
+        <FieldInput
+          focused={true}
+          name="username"
+          fieldType="text"
+          startValue="Username"
+          writeType="input"
+          handleEvent={function () {}} />
+      );
+
+      jest.runAllTimers();
+
+      let input = TestUtils
+        .findRenderedDOMComponentWithTag(instance, 'input');
+
+      expect(input.selectionStart).toEqual(8);
+      expect(input.selectionEnd).toEqual(8);
     });
   });
 


### PR DESCRIPTION
This PR enables to specify an input field (of type text) to be focused and with the cursor set at the end of the input whenever a default value is specified.

Example usage

![group](https://cloud.githubusercontent.com/assets/1078545/15330047/660ad2a8-1c5b-11e6-9855-392b5d093ec0.gif)
