### PR TITLE
Fix update height issue in modal

### DIFF
--- a/src/Modal/ModalContents.js
+++ b/src/Modal/ModalContents.js
@@ -101,8 +101,8 @@ class ModalContents extends Util.mixin(BindMixin, KeyDownMixin) {
     // Default update height to whether there is some change in height
     let update = prevHeight !== height || prevContentHeight !== contentHeight;
 
-    // Make sure to update heightInfo with new height difference
     if (prevInnerContentHeight != null) {
+      // Make sure to update heightInfo with new height difference
       let difference = innerContentHeight - prevInnerContentHeight;
       if (difference !== 0 && height + difference < maxHeight) {
         // Changes this.heightInfo as this is a reference
@@ -110,10 +110,8 @@ class ModalContents extends Util.mixin(BindMixin, KeyDownMixin) {
         heightInfo.contentHeight += difference;
         update = true;
       }
-    }
 
-    // Make sure to update heightInfo with new max height difference
-    if (innerContentHeight != null) {
+      // Make sure to update heightInfo with new max height difference
       let maxHeightDifference = maxHeight - prevMaxHeight;
       if (maxHeightDifference > 0 &&
         (heightInfo.contentHeight + difference < innerContentHeight)) {

--- a/src/Modal/ModalContents.js
+++ b/src/Modal/ModalContents.js
@@ -92,30 +92,41 @@ class ModalContents extends Util.mixin(BindMixin, KeyDownMixin) {
   }
 
   checkContentHeightChange(prevHeightInfo, heightInfo) {
-    let {height, maxHeight, innerContentHeight} = heightInfo;
-    let prevContentHeight = prevHeightInfo.innerContentHeight;
+    let {contentHeight, height, maxHeight, innerContentHeight} = heightInfo;
+    let prevInnerContentHeight = prevHeightInfo.innerContentHeight;
+    let prevHeight = prevHeightInfo.height;
+    let prevContentHeight = prevHeightInfo.contentHeight;
     let prevMaxHeight = prevHeightInfo.maxHeight;
-    let update = false;
 
-    if (prevContentHeight != null) {
-      let difference = innerContentHeight - prevContentHeight;
+    // Default update height to whether there is some change in height
+    let update = prevHeight !== height || prevContentHeight !== contentHeight;
+
+    // Make sure to update heightInfo with new height difference
+    if (prevInnerContentHeight != null) {
+      let difference = innerContentHeight - prevInnerContentHeight;
       if (difference !== 0 && height + difference < maxHeight) {
+        // Changes this.heightInfo as this is a reference
         heightInfo.height += difference;
         heightInfo.contentHeight += difference;
         update = true;
       }
+    }
 
+    // Make sure to update heightInfo with new max height difference
+    if (innerContentHeight != null) {
       let maxHeightDifference = maxHeight - prevMaxHeight;
       if (maxHeightDifference > 0 &&
         (heightInfo.contentHeight + difference < innerContentHeight)) {
+        // Changes this.heightInfo as this is a reference
         heightInfo.height += maxHeightDifference;
         heightInfo.contentHeight += maxHeightDifference;
         update = true;
       }
 
-      if (update) {
-        this.forceUpdate();
-      }
+    }
+
+    if (update) {
+      this.forceUpdate();
     }
   }
 


### PR DESCRIPTION
This fixes an height update problem with modal. It would not update the height unless you explicitly updated the the container of the component twice.

Before:
![](http://cl.ly/0W1C062b0X1t/Screen%20Recording%202016-05-17%20at%2016.55.gif)

After:
![](http://cl.ly/393q0K0h1T3c/Screen%20Recording%202016-05-17%20at%2016.52.gif)