### PR TITLE
Adding more specific node and npm requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: node_js
 node_js:
-  - "4"
+  - "4.3"
+before_install:
+  - if [[ `npm -v` != 2.10* ]]; then npm i -g npm@2.10; fi

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "url": "http://www.mesosphere.com"
   },
   "engines": {
-    "node": "^4.x.x",
-    "npm": "^2.x.x"
+    "node": "^4.3.x",
+    "npm": "^2.10.x"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The build and running tests was failing for me using node `4.4.x` and npm `2.15.x`. Specifying requirements should help others not end up in the same situation.

![](http://cl.ly/2Z45031M280V/Image%202016-05-23%20at%2015.10.36.png)