### PR TITLE
Checkbox radio button follow up

### DIFF
--- a/src/Form/FieldCheckbox.js
+++ b/src/Form/FieldCheckbox.js
@@ -48,7 +48,7 @@ class FieldCheckbox extends FieldRadioButton {
       props.handleEvent(
         eventName,
         props.name,
-        [{name, checked: event.target.checked}],
+        {name, checked: event.target.checked},
         event
       );
     }
@@ -76,7 +76,11 @@ class FieldCheckbox extends FieldRadioButton {
   }
 
   getItem(eventName, labelClass, attributes, index) {
-    let labelClasses = classNames(labelClass, {mute: attributes.disabled});
+    let labelClasses = classNames(
+      labelClass,
+      {mute: attributes.disabled},
+      attributes.labelClass
+    );
 
     return (
       <label className={labelClasses} key={index}>

--- a/src/Form/FieldRadioButton.js
+++ b/src/Form/FieldRadioButton.js
@@ -91,7 +91,11 @@ class FieldRadioButton extends Util.mixin(BindMixin) {
   }
 
   getItem(eventName, labelClass, attributes, index) {
-    let labelClasses = classNames(labelClass, {mute: attributes.disabled});
+    let labelClasses = classNames(
+      labelClass,
+      {mute: attributes.disabled},
+      attributes.labelClass
+    );
 
     return (
       <label className={labelClasses} key={index}>

--- a/src/Form/Form.js
+++ b/src/Form/Form.js
@@ -141,12 +141,16 @@ class Form extends Util.mixin(BindMixin) {
     let model = Util.clone(this.state.model);
     model[field].forEach(function (item) {
       let {name} = item;
-      values.forEach(function (value) {
-        // Update value in field
-        if (name === value.name) {
-          Util.extend(item, value);
-        }
-      });
+      if (Util.isArray(values)) {
+        values.forEach(function (value) {
+          // Update value in field
+          if (name === value.name) {
+            Util.extend(item, value);
+          }
+        });
+      } else if (name === values.name) {
+        Util.extend(item, values);
+      }
     });
 
     this.setState({model});

--- a/src/Form/__tests__/FieldCheckbox-test.js
+++ b/src/Form/__tests__/FieldCheckbox-test.js
@@ -183,7 +183,7 @@ describe('FieldCheckbox', function () {
       var args = this.handleEventSpy.mostRecentCall.args;
       expect(args[0]).toEqual('multipleChange');
       expect(args[1]).toEqual('foo');
-      expect(args[2]).toEqual([{name: 'foo', checked: true}]);
+      expect(args[2]).toEqual({name: 'foo', checked: true});
     });
 
     it('should call handleChange with \'change\' on single item', function () {
@@ -217,7 +217,7 @@ describe('FieldCheckbox', function () {
         // Field name
         'foo',
          // Changed radio buttons
-        [{name: 'quis', checked: true}],
+        {name: 'quis', checked: true},
          // Event fired
         {target: {checked: true}}
       );


### PR DESCRIPTION
Aligning checkbox, with how it used to work before.

To adhere to the radio buttons requirements of having multiple fields change at the same time, arrays were passed to the `onChange` handler, and for checkboxes that meant that arrays of singe items was being passed. This, however, doesn't make too much sense for the users perspective, so I changed the handler to handle both cases, i.e. _arrays_ (for radio buttons) and _single items_ (for checkboxes).