### PR TITLE
Form return updated model on change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - #262 – Change Checkbox component to extend Radio Button component and reuse functionality. Functionality of FieldCheckbox and FieldCheckboxMultiple is now both contained in FieldCheckbox.
 - #275 - Pass through all data on change in Form FieldSelect
 - #276 - Change Form updating to delete fields that are no longer part of the definition.
+- #280 - Make sure Form always returns the latest model to on change handler
 
 ### Fixed
 

--- a/src/Form/Form.js
+++ b/src/Form/Form.js
@@ -122,7 +122,6 @@ class Form extends Util.mixin(BindMixin) {
     // If there is no change to the model, just return the old one
     let newModel = newState.model || this.state.model;
     this.props.onChange(newModel, eventObj, ...rest);
-    console.log(this.state);
     if (Object.keys(newState).length) {
       this.setState(newState);
     }


### PR DESCRIPTION
In certain scenarios, an outdated model would be returned to the `onChange` handler, since `setState` is asynchronous.

This PR fixes that problem and makes sure to always return the most up-to-date model on change