### PR TITLE
Find existing ID in dropdown options

### DIFF
--- a/src/Form/FieldSelect.js
+++ b/src/Form/FieldSelect.js
@@ -44,10 +44,25 @@ class FieldSelect extends React.Component {
     }
 
     if (typeof startValue === 'string') {
-      startValue = {
-        html: startValue,
-        id: startValue
-      };
+      // Try to find id in dropdown items
+      let existingOption = dropdownItems.reduce(function (memo, option) {
+        if (typeof option === 'object') {
+          if (option.id === startValue) {
+            memo = option;
+          }
+        }
+
+        return memo;
+      }, null);
+
+      if (existingOption) {
+        startValue = existingOption;
+      } else {
+        startValue = {
+          html: startValue,
+          id: startValue
+        };
+      }
     }
 
     return (


### PR DESCRIPTION
If we provide a string as `startValue` then we want it to match an existing option first (if one is available).