### PR TITLE
Properly obey initial sort order

### DIFF
--- a/src/Table/Table.js
+++ b/src/Table/Table.js
@@ -57,8 +57,11 @@ class Table extends React.Component {
   }
 
   componentWillMount() {
-    if (this.props.sortBy.prop) {
-      this.handleSort(this.props.sortBy.prop);
+    if (!!this.props.sortBy) {
+      this.setState(
+        {sortBy: this.props.sortBy},
+        this.handleSort.bind(this, this.props.sortBy.prop, {toggle: false})
+      );
     }
   }
 

--- a/src/Table/Table.js
+++ b/src/Table/Table.js
@@ -57,7 +57,7 @@ class Table extends React.Component {
   }
 
   componentWillMount() {
-    if (!!this.props.sortBy) {
+    if (this.props.sortBy != null) {
       this.setState(
         {sortBy: this.props.sortBy},
         this.handleSort.bind(this, this.props.sortBy.prop, {toggle: false})

--- a/src/Table/__tests__/Table-test.js
+++ b/src/Table/__tests__/Table-test.js
@@ -81,4 +81,41 @@ describe('Table', function () {
 
   });
 
+  describe('initial sorting', function () {
+
+    it('should sort the data descending on initial mount', function () {
+      this.instance = TestUtils.renderIntoDocument(
+        <Table
+          className="table"
+          columns={MockTable.columns}
+          data={MockTable.rows}
+          itemHeight={20}
+          sortBy={{prop: 'name', order: 'desc'}} />
+      );
+
+      var tableRows = TestUtils.scryRenderedDOMComponentsWithTag(this.instance, 'tr');
+
+      expect(tableRows[2].children[0].textContent).toEqual('Zach');
+      expect(tableRows[6].children[0].textContent).toEqual('Francis');
+    });
+
+    it('should sort the data ascending on initial mount', function () {
+      this.instance = TestUtils.renderIntoDocument(
+        <Table
+          className="table"
+          columns={MockTable.columns}
+          data={MockTable.rows}
+          itemHeight={20}
+          sortBy={{prop: 'name', order: 'asc'}}
+          onSortCallback={this.callback} />
+      );
+
+      var tableRows = TestUtils.scryRenderedDOMComponentsWithTag(this.instance, 'tr');
+
+      expect(tableRows[2].children[0].textContent).toEqual('Francis');
+      expect(tableRows[6].children[0].textContent).toEqual('Zach');
+    });
+
+  });
+
 });


### PR DESCRIPTION
Fixes bug where the `Table` would not obey its initial sort order.