### PR TITLE
Move padding to inside of scroll container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - #280 - Make sure Form always returns the latest model to on change handler
 - #279 - Make all form elements use classname/dedupe to allow for more class customizability
 - #289 - Don't transform form field select option ids to lower case
+- #296 - Set padding of modal inside scrollable component rathe than outside
 
 ### Fixed
 

--- a/src/Modal/ModalContents.js
+++ b/src/Modal/ModalContents.js
@@ -270,7 +270,11 @@ class ModalContents extends Util.mixin(BindMixin, KeyDownMixin) {
 
   getModalContent(useScrollbar, contentHeight) {
     if (!useScrollbar) {
-      return this.props.children;
+      return (
+        <div className={this.props.scrollContainerClass}>
+          {this.props.children}
+        </div>
+      );
     }
 
     let geminiContainerStyle = {
@@ -282,7 +286,7 @@ class ModalContents extends Util.mixin(BindMixin, KeyDownMixin) {
         autoshow={true}
         className="container-scrollable"
         style={geminiContainerStyle}>
-        <div ref="innerContent">
+        <div className={this.props.scrollContainerClass} ref="innerContent">
           {this.props.children}
         </div>
       </GeminiScrollbar>
@@ -396,9 +400,8 @@ ModalContents.defaultProps = {
   footerContainerClass: 'container',
   headerClass: 'modal-header',
   headerContainerClass: 'container',
-  innerBodyClass: 'modal-content-inner container container-pod ' +
-    'container-pod-short',
   modalClass: 'modal modal-large',
+  scrollContainerClass: 'modal-content-inner',
   titleClass: 'modal-header-title text-align-center flush-top flush-bottom'
 };
 
@@ -458,6 +461,7 @@ ModalContents.propTypes = {
   innerBodyClass: PropTypes.string,
   modalClass: PropTypes.string,
   modalWrapperClass: PropTypes.string,
+  scrollContainerClass: PropTypes.string,
   titleClass: PropTypes.string
 };
 


### PR DESCRIPTION
This PR moves the padding for the modal's content to inside the scroll container.

Here it is in action:
![](https://s3.amazonaws.com/f.cl.ly/items/123v1a103q0U3J0R2j2q/Screen%20Recording%202016-06-27%20at%2001.47%20PM.gif?v=dc347db2)