### PR TITLE
Add release-beta script

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,9 @@
     "livereload": "NODE_ENV='development' ./node_modules/.bin/gulp docs:livereload",
     "npm-publish": "npm publish ./",
     "test": "jest",
-    "release": "npm run clean && npm run test && ./node_modules/.bin/gulp eslint && npm run dist-src && npm publish ./"
+    "release": "npm run clean && npm run test && ./node_modules/.bin/gulp eslint && npm run dist-src && npm publish ./",
+    "release-beta": "npm run clean && npm run test && ./node_modules/.bin/gulp eslint && npm run dist-src && npm version prerelease",
+    "postversion": "npm publish ./ --tag $npm_package_version"
   },
   "jest": {
     "globals": {


### PR DESCRIPTION
Currently, I have the `npm publish` in the `postversion` script. the `postversion` automatically tags the publish with the version, which means it won't be on `latest`. the functionality will have to change if we ever want to create a `release-patch` script