### PR TITLE
Use fixed positioning for Dropdown

### DIFF
--- a/src/Dropdown/dropdown.less
+++ b/src/Dropdown/dropdown.less
@@ -98,6 +98,7 @@
 .dropdown-menu {
   // This can be removed when Canvas is updated to toggle visibility: visible
   display: block !important;
+  position: fixed;
   z-index: 1;
 
   &.up {


### PR DESCRIPTION
This PR changes the dropdown to use fixed positioning, which allows it to render outside of elements whose overflowing content is clipped.

See it in action:
![](https://s3.amazonaws.com/f.cl.ly/items/3J0O34313a2J0f2Q2O2s/Screen%20Recording%202016-07-26%20at%2003.51%20PM.gif?v=b3e3241c)

It will close automatically when its parent container scrolls.

One breaking change was introduced with this refactor. To anchor dropdowns to the right of the dropdown button, we must now do it via a boolean passed to the `Dropdown` called `anchorRight`. This is due to the fixed positioning.