### PR TITLE
Find native scroll container if Gemini isn't needed

### DIFF
--- a/src/Dropdown/Dropdown.js
+++ b/src/Dropdown/Dropdown.js
@@ -185,16 +185,20 @@ class Dropdown extends Util.mixin(BindMixin, KeyDownMixin) {
     let {scrollContainer, scrollContainerParentSelector} = this.props;
 
     if (typeof scrollContainer === 'string') {
-      let scrollContainerSelector = null;
+      // Find the closest scrolling element by the specified selector.
+      scrollContainer = DOMUtil.closest(ReactDOM.findDOMNode(this),
+        scrollContainer) || window;
 
-      if (scrollContainerParentSelector == null) {
-        scrollContainerSelector = scrollContainer;
-      } else {
-        scrollContainerSelector = scrollContainerParentSelector;
+      let {parentElement} = scrollContainer;
+
+      // If the user specified scrollContainerParentSelector, we check to see
+      // if the parent scrolling element matches the specified parent selector.
+      if (scrollContainer != window && scrollContainerParentSelector != null
+        && parentElement != null && parentElement[DOMUtil.matchesFn](
+          scrollContainerParentSelector
+        )) {
+        scrollContainer = parentElement;
       }
-
-      return DOMUtil.closest(ReactDOM.findDOMNode(this),
-        scrollContainerSelector) || window;
     }
 
     return scrollContainer;

--- a/src/Dropdown/Dropdown.js
+++ b/src/Dropdown/Dropdown.js
@@ -49,16 +49,16 @@ class Dropdown extends Util.mixin(BindMixin, KeyDownMixin) {
 
   componentDidMount() {
     if (typeof this.props.scrollContainer === 'string') {
-      this.container = DOMUtil.closest(ReactDOM.findDOMNode(this),
-        this.props.scrollContainer) || window;
+      let scrollingNodeSelector = null;
 
-      if (this.container.parentElement != null
-        && this.props.scrollContainerParentSelector != null
-        && this.container.parentElement[DOMUtil.matchesFn](
-          this.props.scrollContainerParentSelector
-        )) {
-        this.container = this.container.parentElement;
+      if (this.props.scrollContainerParentSelector == null) {
+        scrollingNodeSelector = this.props.scrollContainer;
+      } else {
+        scrollingNodeSelector = this.props.scrollContainerParentSelector;
       }
+
+      this.container = DOMUtil.closest(ReactDOM.findDOMNode(this),
+        scrollingNodeSelector) || window;
 
       return;
     }

--- a/src/Dropdown/Dropdown.js
+++ b/src/Dropdown/Dropdown.js
@@ -48,22 +48,7 @@ class Dropdown extends Util.mixin(BindMixin, KeyDownMixin) {
   }
 
   componentDidMount() {
-    if (typeof this.props.scrollContainer === 'string') {
-      let scrollingNodeSelector = null;
-
-      if (this.props.scrollContainerParentSelector == null) {
-        scrollingNodeSelector = this.props.scrollContainer;
-      } else {
-        scrollingNodeSelector = this.props.scrollContainerParentSelector;
-      }
-
-      this.container = DOMUtil.closest(ReactDOM.findDOMNode(this),
-        scrollingNodeSelector) || window;
-
-      return;
-    }
-
-    this.container = this.props.scrollContainer;
+    this.container = this.getScrollContainer();
   }
 
   componentWillUpdate(nextProps, nextState) {
@@ -194,6 +179,25 @@ class Dropdown extends Util.mixin(BindMixin, KeyDownMixin) {
         </li>
       );
     });
+  }
+
+  getScrollContainer() {
+    let {scrollContainer, scrollContainerParentSelector} = this.props;
+
+    if (typeof scrollContainer === 'string') {
+      let scrollContainerSelector = null;
+
+      if (scrollContainerParentSelector == null) {
+        scrollContainerSelector = scrollContainer;
+      } else {
+        scrollContainerSelector = scrollContainerParentSelector;
+      }
+
+      return DOMUtil.closest(ReactDOM.findDOMNode(this),
+        scrollContainerSelector) || window;
+    }
+
+    return scrollContainer;
   }
 
   getSelectedHtml(id, items) {

--- a/src/Dropdown/Dropdown.js
+++ b/src/Dropdown/Dropdown.js
@@ -47,6 +47,25 @@ class Dropdown extends Util.mixin(BindMixin, KeyDownMixin) {
     }
   }
 
+  componentDidMount() {
+    if (typeof this.props.scrollContainer === 'string') {
+      this.container = DOMUtil.closest(ReactDOM.findDOMNode(this),
+        this.props.scrollContainer) || window;
+
+      if (this.container.parentElement != null
+        && this.props.scrollContainerParentSelector != null
+        && this.container.parentElement[DOMUtil.matchesFn](
+          this.props.scrollContainerParentSelector
+        )) {
+        this.container = this.container.parentElement;
+      }
+
+      return;
+    }
+
+    this.container = this.props.scrollContainer;
+  }
+
   componentWillUpdate(nextProps, nextState) {
     // If the open state changed, add or remove listener as needed.
     if (nextState.isOpen !== this.state.isOpen) {
@@ -98,15 +117,6 @@ class Dropdown extends Util.mixin(BindMixin, KeyDownMixin) {
   }
 
   addScrollListener() {
-    if (!this.container) {
-      if (typeof this.props.scrollContainer === 'string') {
-        this.container = DOMUtil.closest(ReactDOM.findDOMNode(this),
-          this.props.scrollContainer) || window;
-      } else {
-        this.container = this.props.scrollContainer;
-      }
-    }
-
     this.container.addEventListener('scroll', this.closeDropdown);
   }
 
@@ -396,6 +406,7 @@ class Dropdown extends Util.mixin(BindMixin, KeyDownMixin) {
 Dropdown.defaultProps = {
   anchorRight: false,
   scrollContainer: window,
+  scrollContainerParentSelector: null,
   transition: false,
   transitionName: 'dropdown-menu',
   transitionEnterTimeout: 250,
@@ -450,6 +461,9 @@ Dropdown.propTypes = {
   // window. Also accepts a string, treated as a selector for the node.
   scrollContainer: React.PropTypes.oneOfType([React.PropTypes.object,
     React.PropTypes.string]),
+  // Will attach the scroll handler to the the direct parent of scrollContainer
+  // if it matches this selector. Defaults to null.
+  scrollContainerParentSelector: React.PropTypes.string,
   // Optional transition on the dropdown menu. Must be accompanied
   // by an animation or transition in CSS.
   transition: React.PropTypes.bool,

--- a/src/Util/DOMUtil.js
+++ b/src/Util/DOMUtil.js
@@ -8,12 +8,28 @@ var computeInnerBound = function (compstyle, acc, key) {
   }
 };
 
+var matchesFn = (function () {
+  var el = document.querySelector('body');
+  var names = [
+    'matches', 'matchesSelector', 'msMatchesSelector',
+    'oMatchesSelector', 'mozMatchesSelector', 'webkitMatchesSelector'
+  ];
+
+  for (var i = 0; i < names.length; i++) {
+    if (el[names[i]]) {
+      return names[i];
+    }
+  }
+
+  return names[0];
+})();
+
 const DOMUtil = {
   closest(el, selector) {
     var currentEl = el;
 
     while (currentEl && currentEl.parentElement !== null) {
-      if (currentEl[this.matchesFn] && currentEl[this.matchesFn](selector)) {
+      if (currentEl[matchesFn] && currentEl[matchesFn](selector)) {
         return currentEl;
       }
 
@@ -104,23 +120,7 @@ const DOMUtil = {
     } else {
       return element.scrollTop;
     }
-  },
-
-  matchesFn: (function () {
-    let el = document.querySelector('body');
-    let names = [
-      'matches', 'matchesSelector', 'msMatchesSelector',
-      'oMatchesSelector', 'mozMatchesSelector', 'webkitMatchesSelector'
-    ];
-
-    for (let i = 0; i < names.length; i++) {
-      if (el[names[i]]) {
-        return names[i];
-      }
-    }
-
-    return names[0];
-  })()
+  }
 };
 
 module.exports = DOMUtil;

--- a/src/Util/DOMUtil.js
+++ b/src/Util/DOMUtil.js
@@ -8,28 +8,12 @@ var computeInnerBound = function (compstyle, acc, key) {
   }
 };
 
-var matchesFn = (function () {
-  var el = document.querySelector('body');
-  var names = [
-    'matches', 'matchesSelector', 'msMatchesSelector',
-    'oMatchesSelector', 'mozMatchesSelector', 'webkitMatchesSelector'
-  ];
-
-  for (var i = 0; i < names.length; i++) {
-    if (el[names[i]]) {
-      return names[i];
-    }
-  }
-
-  return names[0];
-})();
-
 const DOMUtil = {
   closest(el, selector) {
     var currentEl = el;
 
     while (currentEl && currentEl.parentElement !== null) {
-      if (currentEl[matchesFn] && currentEl[matchesFn](selector)) {
+      if (currentEl[this.matchesFn] && currentEl[this.matchesFn](selector)) {
         return currentEl;
       }
 
@@ -120,7 +104,23 @@ const DOMUtil = {
     } else {
       return element.scrollTop;
     }
-  }
+  },
+
+  matchesFn: (function () {
+    let el = document.querySelector('body');
+    let names = [
+      'matches', 'matchesSelector', 'msMatchesSelector',
+      'oMatchesSelector', 'mozMatchesSelector', 'webkitMatchesSelector'
+    ];
+
+    for (let i = 0; i < names.length; i++) {
+      if (el[names[i]]) {
+        return names[i];
+      }
+    }
+
+    return names[0];
+  })()
 };
 
 module.exports = DOMUtil;


### PR DESCRIPTION
This PR introduces the ability to provide a selector via the prop `scrollContainerParentSelector`. If it matches the parent of the `scrollContainer` element, the scroll event handler will be attached to the parent element rather than `scrollContainer`.

This is necessary due to Gemini changing which element handles overflowing content dependent upon OS-specific settings. If the OS does not render overlay scrollbars, Gemini handles scrolling in a div with class `gm-scroll-view`. If the OS does render native overlay scrollbars, Gemini does nothing except add DOM nodes, so the direct parent of the Gemini component is left responsible for the scroll behavior.

This PR also exposes the `matchesFn` in `DOMUtil` which is now consumed by the `Dropdown`.