### PR TITLE
Fix beta release script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,19 +74,9 @@ After this you can pull down the latest module version from npm.
 
 1. Make sure you are on `master` branch and have pulled the latest changes.
 
-2. Create the tag as outlined above, with the full version number (including beta).
+2. Run the `release-beta` NPM script:
 
-3. Push the new tag to github:
-
-        git push --tags
-
-4. Compile the assets for distribution:
-
-        npm run dist-src
-
-5. Now do the release with the proper flags, where `{NUMBER}` is the beta number you wish to release:
-
-        npm publish ./ --tag -.beta-{NUMBER}
+        npm run release-beta
 
 ## Making a PR
 

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "test": "jest",
     "release": "npm run clean && npm run test && ./node_modules/.bin/gulp eslint && npm run dist-src && npm publish ./",
     "release-beta": "npm run clean && npm run test && ./node_modules/.bin/gulp eslint && npm run dist-src && npm version prerelease",
-    "postversion": "npm publish ./ --tag $npm_package_version"
+    "postversion": "npm publish ./ --tag version-$npm_package_version"
   },
   "jest": {
     "globals": {


### PR DESCRIPTION
This PR prepends the text `version-` to the version tag, because NPM rejects any tag that begins with `v` or a number. It also fixes the `CONTRIBUTING.md` document to include the usage of the script.