### PR TITLE
Implement auto-expanding "TextArea"

### DIFF
--- a/src/Form/FieldInput.js
+++ b/src/Form/FieldInput.js
@@ -2,13 +2,14 @@ import classNames from 'classnames/dedupe';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
+import BindMixin from '../Mixin/BindMixin';
 import IconEdit from './icons/IconEdit';
 import KeyboardUtil from '../Util/KeyboardUtil';
 import Util from '../Util/Util';
 
 const EVENTS = ['blur', 'change', 'focus'];
 
-class FieldInput extends React.Component {
+class FieldInput extends Util.mixin(BindMixin) {
   shouldComponentUpdate(nextProps, nextState) {
     return !Util.isEqual(this.props, nextProps) || !Util.isEqual(this.state, nextState);
   }

--- a/src/Form/FieldInput.js
+++ b/src/Form/FieldInput.js
@@ -9,8 +9,8 @@ import Util from '../Util/Util';
 const EVENTS = ['blur', 'change', 'focus'];
 
 class FieldInput extends React.Component {
-  shouldComponentUpdate(nextProps) {
-    return !Util.isEqual(this.props, nextProps);
+  shouldComponentUpdate(nextProps, nextState) {
+    return !Util.isEqual(this.props, nextProps) || !Util.isEqual(this.state, nextState);
   }
 
   componentDidUpdate() {

--- a/src/Form/FieldInput.js
+++ b/src/Form/FieldInput.js
@@ -10,7 +10,7 @@ import Util from '../Util/Util';
 const EVENTS = ['blur', 'change', 'focus'];
 
 class FieldInput extends Util.mixin(BindMixin) {
-  shouldComponentUpdate(nextProps, nextState) {
+  shouldComponentUpdate(nextProps) {
     return !Util.isEqual(this.props, nextProps);
   }
 

--- a/src/Form/FieldInput.js
+++ b/src/Form/FieldInput.js
@@ -11,7 +11,7 @@ const EVENTS = ['blur', 'change', 'focus'];
 
 class FieldInput extends Util.mixin(BindMixin) {
   shouldComponentUpdate(nextProps, nextState) {
-    return !Util.isEqual(this.props, nextProps) || !Util.isEqual(this.state, nextState);
+    return !Util.isEqual(this.props, nextProps);
   }
 
   componentDidUpdate() {

--- a/src/Form/FieldTextarea.js
+++ b/src/Form/FieldTextarea.js
@@ -11,7 +11,9 @@ class FieldTextarea extends FieldInput {
   constructor() {
     super(...arguments);
 
-    this.state = {height: 0};
+    this.state = {height: this.props.minHeight};
+
+    console.log(this.props);
 
     this.updateTextareaHeight = Util.throttle(this.updateTextareaHeight, 100);
     this.handleContentEditableBlur = this.handleContentEditableBlur.bind(this);
@@ -19,10 +21,6 @@ class FieldTextarea extends FieldInput {
       this.handleContentEditableChange.bind(this);
     this.handleContentEditableFocus =
       this.handleContentEditableFocus.bind(this);
-  }
-
-  componentWillMount() {
-    this.setState({height: this.props.minHeight});
   }
 
   componentDidMount() {

--- a/src/Form/FieldTextarea.js
+++ b/src/Form/FieldTextarea.js
@@ -38,6 +38,10 @@ class FieldTextarea extends FieldInput {
     }
   }
 
+  shouldComponentUpdate(nextProps, nextState) {
+    return !Util.isEqual(this.props, nextProps) || !Util.isEqual(this.state, nextState);
+  }
+
   handleContentEditableBlur(event) {
     let {props} = this;
     props.handleEvent('blur', props.name, event.target.innerText, event);

--- a/src/Form/FieldTextarea.js
+++ b/src/Form/FieldTextarea.js
@@ -8,19 +8,19 @@ import IconEdit from './icons/IconEdit';
 import Util from '../Util/Util';
 
 class FieldTextarea extends FieldInput {
+  get methodsToBind() {
+    return [
+      'handleContentEditableBlur',
+      'handleContentEditableChange',
+      'handleContentEditableFocus'
+    ]
+  }
+
   constructor() {
     super(...arguments);
 
     this.state = {height: this.props.minHeight};
-
-    console.log(this.props);
-
     this.updateTextareaHeight = Util.throttle(this.updateTextareaHeight, 100);
-    this.handleContentEditableBlur = this.handleContentEditableBlur.bind(this);
-    this.handleContentEditableChange =
-      this.handleContentEditableChange.bind(this);
-    this.handleContentEditableFocus =
-      this.handleContentEditableFocus.bind(this);
   }
 
   componentDidMount() {

--- a/src/Form/FieldTextarea.js
+++ b/src/Form/FieldTextarea.js
@@ -5,13 +5,64 @@ import React from 'react';
 
 import FieldInput from './FieldInput';
 import IconEdit from './icons/IconEdit';
+import Util from '../Util/Util';
 
-module.exports = class FieldTextarea extends FieldInput {
+class FieldTextarea extends FieldInput {
+  constructor() {
+    super(...arguments);
+
+    this.state = {height: 0};
+
+    this.updateTextareaHeight = Util.throttle(this.updateTextareaHeight, 100);
+    this.handleContentEditableBlur = this.handleContentEditableBlur.bind(this);
+    this.handleContentEditableChange =
+      this.handleContentEditableChange.bind(this);
+    this.handleContentEditableFocus =
+      this.handleContentEditableFocus.bind(this);
+  }
+
+  componentWillMount() {
+    this.setState({height: this.props.minHeight});
+  }
+
+  componentDidMount() {
+    super.componentDidMount(...arguments);
+
+    if (this.isEditing() || this.props.writeType === 'input') {
+      this.updateTextareaHeight(this.refs.inputElement);
+
+      // React throws a warning if children are specified in an element with
+      // contenteditable="true", so this hack allows us to set a default value
+      // for this form field.
+      if (this.props.startValue) {
+        this.refs.inputElement.textContent = this.props.startValue;
+      }
+    }
+  }
+
+  handleContentEditableBlur(event) {
+    let {props} = this;
+    props.handleEvent('blur', props.name, event.target.innerText, event);
+  }
+
+  handleContentEditableChange(event) {
+    let {props} = this;
+
+    this.updateTextareaHeight(event.target);
+    props.handleEvent('change', props.name, event.target.innerText, event);
+  }
+
+  handleContentEditableFocus(event) {
+    let {props} = this;
+    props.handleEvent('focus', props.name, event.target.innerText, event);
+  }
+
   getInputElement(attributes) {
     let {
       inlineIconClass,
       inlineTextClass,
       inputClass,
+      minHeight,
       renderer,
       sharedClass,
       value,
@@ -19,16 +70,29 @@ module.exports = class FieldTextarea extends FieldInput {
     } = this.props;
     let inputContent = null;
 
-    let classes = classNames(inputClass, sharedClass);
+    let classes = classNames(
+      'content-editable',
+      inputClass,
+      sharedClass
+    );
+
     attributes = this.bindEvents(attributes);
 
     if (this.isEditing() || writeType === 'input') {
       inputContent = (
-        <textarea
-          ref="inputElement"
-          className={classes}
-          {...attributes}
-          value={attributes.startValue} />
+        <div
+          className="content-editable-wrapper"
+          style={{height: `${this.state.height}px`}}>
+          <div
+            ref="inputElement"
+            className={classes}
+            {...attributes}
+            contentEditable={true}
+            onBlur={this.handleContentEditableBlur}
+            onFocus={this.handleContentEditableFocus}
+            onInput={this.handleContentEditableChange}
+            style={{minHeight: `${minHeight}px`}} />
+        </div>
       );
     } else {
       inputContent = (
@@ -53,4 +117,34 @@ module.exports = class FieldTextarea extends FieldInput {
 
     return inputContent;
   }
+
+  updateTextareaHeight(domElement) {
+    let {minHeight, maxHeight, scrollHeightOffset} = this.props;
+    let newHeight = minHeight;
+    let {offsetHeight, scrollHeight} = domElement;
+
+    if (scrollHeight > minHeight && scrollHeight < maxHeight) {
+      newHeight = scrollHeight + scrollHeightOffset;
+    } else if (scrollHeight >= maxHeight) {
+      newHeight = maxHeight;
+    }
+
+    if (newHeight !== this.state.height) {
+      this.setState({height: newHeight});
+    }
+  }
 }
+
+FieldTextarea.defaultProps = {
+  maxHeight: 400,
+  minHeight: 100,
+  scrollHeightOffset: 2
+};
+
+FieldTextarea.propTypes = {
+  maxHeight: React.PropTypes.number,
+  minHeight: React.PropTypes.number,
+  scrollHeightOffset: React.PropTypes.number
+};
+
+module.exports = FieldTextarea;

--- a/src/Form/form.less
+++ b/src/Form/form.less
@@ -280,10 +280,26 @@ base/forms.less
   /* -----------------------------------------------------------------------------
   --------------------------------------------------------------------------------
 
-  Textarea Form Elements
+  "Textarea" Form Elements: A div with attribute contenteditable="true"
 
   --------------------------------------------------------------------------------
   ----------------------------------------------------------------------------- */
+
+  .content-editable-wrapper {
+    position: relative;
+  }
+
+  .content-editable {
+    height: auto;
+    left: 0;
+    max-height: 100%;
+    overflow: auto;
+    position: absolute;
+    top: 0;
+    white-space: pre-wrap;
+    width: 100%;
+    word-wrap: break-word;
+  }
 
   .form-group {
 

--- a/src/Form/form.less
+++ b/src/Form/form.less
@@ -299,6 +299,15 @@ base/forms.less
     white-space: pre-wrap;
     width: 100%;
     word-wrap: break-word;
+
+    // Remove any rich-text styling that might be introduced by a user pasting
+    // rich-text content or using rich-text keyboard shortcuts.
+    * {
+      color: inherit !important;
+      font: inherit !important;
+      text-decoration: inherit !important;
+      text-shadow: inherit !important;
+    }
   }
 
   .form-group {


### PR DESCRIPTION
This PR replaces all `textarea` elements with `div` elements with `contenteditable="true"`.

It seems to work inside DCOS UI, but please test this heavily.

![](https://cl.ly/1N0i0G3q422j/Screen%20Recording%202016-08-02%20at%2002.48%20PM.gif)