### PR TITLE
Add support for dropdown menu matching button width

### DIFF
--- a/src/Dropdown/Dropdown.js
+++ b/src/Dropdown/Dropdown.js
@@ -140,7 +140,10 @@ class Dropdown extends Util.mixin(BindMixin, KeyDownMixin) {
       height = spaceAroundDropdown.bottom;
     }
 
-    if (this.props.anchorRight) {
+    if (this.props.matchButtonWidth) {
+      position.left = spaceAroundDropdown.left;
+      position.right = spaceAroundDropdown.right;
+    } else if (this.props.anchorRight) {
       position.right = spaceAroundDropdown.right;
     } else {
       position.left = spaceAroundDropdown.left;
@@ -308,7 +311,6 @@ class Dropdown extends Util.mixin(BindMixin, KeyDownMixin) {
       'open': state.isOpen
     };
     let items = props.items;
-    let menuPosition = {};
     let transitionName =
       `${props.transitionName}-${state.menuDirection}`;
     let wrapperClassSet = classNames(
@@ -327,7 +329,7 @@ class Dropdown extends Util.mixin(BindMixin, KeyDownMixin) {
           {this.getMenuItems(props.items)}
         </ul>
       );
-      let menuPosition = Object.assign({}, state.menuPosition);
+      let dropdownMenuWrapperStyle = Object.assign({}, state.menuPosition);
 
       // Render with Gemini scrollbar if the dropdown's height is constrainted.
       if (state.menuHeight >= state.maxDropdownHeight) {
@@ -336,6 +338,7 @@ class Dropdown extends Util.mixin(BindMixin, KeyDownMixin) {
         dropdownMenuStyle = {
           height: `${state.maxDropdownHeight - 30}px`
         };
+
         if (props.useGemini) {
           dropdownMenuItems = (
             <GeminiScrollbar
@@ -362,7 +365,7 @@ class Dropdown extends Util.mixin(BindMixin, KeyDownMixin) {
           key={dropdownKey}
           role="menu"
           ref="dropdownMenu"
-          style={menuPosition}>
+          style={dropdownMenuWrapperStyle}>
           <div className={props.dropdownMenuListClassName}>
             {dropdownMenuItems}
           </div>
@@ -413,6 +416,7 @@ class Dropdown extends Util.mixin(BindMixin, KeyDownMixin) {
 
 Dropdown.defaultProps = {
   anchorRight: false,
+  matchButtonWidth: false,
   scrollContainer: window,
   scrollContainerParentSelector: null,
   transition: false,
@@ -462,6 +466,8 @@ Dropdown.propTypes = {
     React.PropTypes.string,
     React.PropTypes.number
   ]),
+  // When true, the width of the dropdown will match the width of the button.
+  matchButtonWidth: React.PropTypes.bool,
   // An optional callback when an item is selected. Will receive an argument
   // containing the selected item as it was supplied via the items array.
   onItemSelection: React.PropTypes.func,


### PR DESCRIPTION
This PR sets the `left` and `right` properties of the dropdown menu to match the `left` and `right` position of the dropdown button.

![](https://d3vv6lp55qjaqc.cloudfront.net/items/1H2Z2j3c2U3m1z1V0b3K/Screen%20Shot%202016-08-02%20at%204.44.57%20PM.png?v=b8dc6e09)