### PR TITLE
Make sure to call form on change after state has been set

### DIFF
--- a/src/Form/Form.js
+++ b/src/Form/Form.js
@@ -125,9 +125,13 @@ class Form extends Util.mixin(BindMixin) {
 
     // If there is no change to the model, just return the old one
     let newModel = newState.model || this.state.model;
-    this.props.onChange(newModel, eventObj, ...rest);
+    let onChange = this.props.onChange.bind(this, newModel, eventObj, ...rest);
     if (Object.keys(newState).length) {
-      this.setState(newState);
+      // Make sure to call onChange on setState callback,
+      // so users can get updated model from triggerSubmit
+      this.setState(newState, onChange);
+    } else {
+      onChange();
     }
   }
 


### PR DESCRIPTION
This will make sure to return updated model on triggerSubmit in onChange callback

Related change: https://github.com/mesosphere/reactjs-components/pull/280/files#diff-035be6cdc63453ed42b5cf6b6fcf34b8R123