### PR TITLE
[CNVS Upgrade: Docs] Add reusable components for creating our docs

### DIFF
--- a/docs/src/components/CodeBlock.js
+++ b/docs/src/components/CodeBlock.js
@@ -1,0 +1,42 @@
+import classnames from 'classnames/dedupe';
+import React from 'react';
+
+class CodeBlock extends React.Component {
+  render() {
+    let panelInnerClasses = classnames(
+      'panel-cell panel-cell-narrow panel-cell-short panel-cell-light panel-cell-code-block',
+      this.props.panelInnerClassNames
+    );
+    let preClasses = classnames(
+      `prettyprint transparent flush lang-${this.props.language}`,
+      this.props.preClassNames
+    );
+
+    return (
+      <div className={panelInnerClasses}>
+        <pre className={preClasses}>
+          {this.props.children}
+        </pre>
+      </div>
+    );
+  }
+}
+
+const classPropTypes = React.PropTypes.oneOfType([
+  React.PropTypes.array,
+  React.PropTypes.object,
+  React.PropTypes.string
+]);
+
+CodeBlock.defaultProps = {
+  language: 'javascript'
+};
+
+CodeBlock.propTypes = {
+  children: React.PropTypes.node.isRequired,
+  language: React.PropTypes.string,
+  panelInnerClassNames: classPropTypes,
+  preClassNames: classPropTypes
+};
+
+module.exports = CodeBlock;

--- a/docs/src/components/CodeBlockWrapper.js
+++ b/docs/src/components/CodeBlockWrapper.js
@@ -1,0 +1,28 @@
+import classnames from 'classnames/dedupe';
+import React from 'react';
+
+class CodeBlockWrapper extends React.Component {
+  render() {
+    let panelClasses = classnames(
+      'panel pod flush-right flush-left flush-top',
+      this.props.panelClassNames
+    );
+
+    return (
+      <div className={panelClasses}>
+        {this.props.children}
+      </div>
+    );
+  }
+}
+
+CodeBlockWrapper.propTypes = {
+  children: React.PropTypes.node.isRequired,
+  panelClassNames: React.PropTypes.oneOfType([
+    React.PropTypes.array,
+    React.PropTypes.object,
+    React.PropTypes.string
+  ])
+};
+
+module.exports = CodeBlockWrapper;

--- a/docs/src/components/ComponentExample.js
+++ b/docs/src/components/ComponentExample.js
@@ -1,0 +1,25 @@
+import classnames from 'classnames/dedupe';
+import React from 'react';
+
+class ComponentExample extends React.Component {
+  render() {
+    let classes = classnames('panel-cell', this.props.classNames);
+
+    return (
+      <div className={classes}>
+        {this.props.children}
+      </div>
+    );
+  }
+}
+
+ComponentExample.propTypes = {
+  children: React.PropTypes.node.isRequired,
+  classNames: React.PropTypes.oneOfType([
+    React.PropTypes.array,
+    React.PropTypes.object,
+    React.PropTypes.string
+  ])
+};
+
+module.exports = ComponentExample;

--- a/docs/src/components/ComponentExampleWrapper.js
+++ b/docs/src/components/ComponentExampleWrapper.js
@@ -1,0 +1,28 @@
+import classnames from 'classnames/dedupe';
+import React from 'react';
+
+class ComponentExampleWrapper extends React.Component {
+  render() {
+    let classes = classnames(
+      'panel pod flush-top flush-right flush-left',
+      this.props.className
+    );
+
+    return (
+      <div className={classes}>
+        {this.props.children}
+      </div>
+    );
+  }
+}
+
+ComponentExampleWrapper.propTypes = {
+  children: React.PropTypes.node.isRequired,
+  className: React.PropTypes.oneOfType([
+    React.PropTypes.array,
+    React.PropTypes.object,
+    React.PropTypes.string
+  ])
+};
+
+module.exports = ComponentExampleWrapper;

--- a/docs/src/components/ComponentWrapper.js
+++ b/docs/src/components/ComponentWrapper.js
@@ -6,32 +6,21 @@ class ComponentWrapper extends React.Component {
   render() {
     let {props} = this;
     return (
-      <div>
-        <section className="row canvas-pod">
-          <div>
-            <div className="row row-flex row-flex-align-vertical-center">
-              <div className="column-12">
-                <h2 className="component-title">
-                  {props.title}
-                  <a href={props.srcURI}>
-                    <IconCode />
-                  </a>
-                </h2>
-                {props.children}
-              </div>
-            </div>
-          </div>
-        </section>
-      </div>
+      <section>
+        <h2 className="component-title">
+          {props.title}
+          <a href={props.srcURI}>
+            <IconCode />
+          </a>
+        </h2>
+        {props.children}
+      </section>
     );
   }
 }
 
 ComponentWrapper.propTypes = {
-  children: React.PropTypes.oneOfType([
-    React.PropTypes.element,
-    React.PropTypes.arrayOf(React.PropTypes.element)
-  ]).isRequired,
+  children: React.PropTypes.node.isRequired,
   srcURI: React.PropTypes.string.isRequired,
   title: React.PropTypes.string.isRequired
 };

--- a/docs/src/components/PropertiesAPIBlock.js
+++ b/docs/src/components/PropertiesAPIBlock.js
@@ -1,6 +1,8 @@
 import classNames from 'classnames';
 import React from 'react';
 
+import CodeBlock from './CodeBlock';
+import CodeBlockWrapper from './CodeBlockWrapper';
 import BindMixin from '../../../src/Mixin/BindMixin';
 import Util from '../../../src/Util/Util';
 
@@ -28,8 +30,8 @@ class PropertiesAPIBlock extends Util.mixin(BindMixin) {
       'example-block-toggle flush-bottom', {
         open: this.state.open
       }, this.props.toggleClasses);
-    let blockClassNames = classNames('example-block', {
-      'show-snippet': !this.state.open
+    let panelInnerClassNames = classNames('example-block', {
+      'is-expanded': !this.state.open
     });
 
     return (
@@ -37,9 +39,11 @@ class PropertiesAPIBlock extends Util.mixin(BindMixin) {
         <h4 className={toggleClasses} onClick={this.handleToggleClick}>
           Properties API
         </h4>
-        <div className={blockClassNames}>
-          <pre className="prettyprint linenums flush-bottom">{this.props.propTypesBlock}</pre>
-        </div>
+        <CodeBlockWrapper>
+          <CodeBlock panelInnerClassNames={panelInnerClassNames}>
+            {this.props.propTypesBlock}
+          </CodeBlock>
+        </CodeBlockWrapper>
       </div>
     );
   }


### PR DESCRIPTION
This PR introduces reusable components to be used in our docs. This removes a lot of the repetition in assigning classes and structuring DOM elements.