### PR TITLE
Fix dropdown height calculation

### DIFF
--- a/src/Dropdown/Dropdown.js
+++ b/src/Dropdown/Dropdown.js
@@ -335,11 +335,16 @@ class Dropdown extends Util.mixin(BindMixin, KeyDownMixin) {
       if (state.menuHeight >= state.maxDropdownHeight) {
         // Remove 30 pixels from the dropdown height to account for offset
         // positioning from the dropdown button.
-        dropdownMenuStyle = {
-          height: `${state.maxDropdownHeight - 30}px`
-        };
 
-        if (props.useGemini) {
+        let height = 'auto';
+
+        if (state.maxDropdownHeight && state.maxDropdownHeight > 30) {
+          height = `${state.maxDropdownHeight - 30}px`
+        }
+
+        dropdownMenuStyle = {height};
+
+        if (props.useGemini && height !== 'auto') {
           dropdownMenuItems = (
             <GeminiScrollbar
             autoshow={true}

--- a/src/Dropdown/Dropdown.js
+++ b/src/Dropdown/Dropdown.js
@@ -333,11 +333,10 @@ class Dropdown extends Util.mixin(BindMixin, KeyDownMixin) {
 
       // Render with Gemini scrollbar if the dropdown's height is constrainted.
       if (state.menuHeight >= state.maxDropdownHeight) {
-        // Remove 30 pixels from the dropdown height to account for offset
-        // positioning from the dropdown button.
-
         let height = 'auto';
 
+        // Remove 30 pixels from the dropdown height to account for offset
+        // positioning from the dropdown button.
         if (state.maxDropdownHeight && state.maxDropdownHeight > 30) {
           height = `${state.maxDropdownHeight - 30}px`
         }


### PR DESCRIPTION
This fixes a bug where the height of the dropdown wasn't calculated properly when Gemini scrollbar was being used in conjunction very long menu.

When a very long dropdown menu rendered for the first time (so it hasn't yet calculated how tall the dropdown menu is), it would render with Gemini (if the props allowed it). This poses a problem because Gemini implements logic to measure its parent's height and then caps the content at this specific height. In the case of the `position: fixed` dropdown, Gemini cannot calculate the parent's height accurately.

Now, when a very large dropdown is rendered and the maximum height of the dropdown has not already been measured, it renders without Gemini, so all subsequent calculations of height are based on the "natural" height of the menu. After the natural height is calculated, it re-renders with Gemini, and all is well.

Before (note the bottom of the menu spilling off the viewport):
![](https://cl.ly/3n2T1p2V2j41/Screen%20Shot%202016-08-30%20at%201.03.17%20PM.png)

After (note the bottom of the menu truncating just before the bottom of the viewport):
![](https://cl.ly/0H1V0o2v3W3A/download/Screen%20Shot%202016-08-30%20at%2012.59.12%20PM.png)