### PR TITLE
Add option to provide key in definition

### DIFF
--- a/src/Form/FormControl.js
+++ b/src/Form/FormControl.js
@@ -33,11 +33,17 @@ class FormControl extends React.Component {
       columnWidth = definition.columnWidth;
     }
 
+    let key = definition.key;
+    // Fallback to using name, if no key provided
+    if (key == null) {
+      key = definition.name;
+    }
+
     return (
       <FieldTypeComponent
         {...Util.exclude(props, 'definition')}
-        {...Util.exclude(definition, 'value', 'fieldType')}
-        key={definition.name}
+        {...Util.exclude(definition, 'value', 'fieldType', 'key')}
+        key={key}
         startValue={props.currentValue[definition.name]}
         type={definition.fieldType}
         columnWidth={columnWidth} />


### PR DESCRIPTION
This PR adds an option to provide a key in the field definition, instead of using the name