### PR TITLE
Remove more styling from content-editable children

### DIFF
--- a/src/Form/form.less
+++ b/src/Form/form.less
@@ -303,10 +303,19 @@ base/forms.less
     // Remove any rich-text styling that might be introduced by a user pasting
     // rich-text content or using rich-text keyboard shortcuts.
     * {
+      background: none !important;
+      border: none !important;
       color: inherit !important;
       font: inherit !important;
+      margin: 0 !important;
+      padding: 0 !important;
       text-decoration: inherit !important;
       text-shadow: inherit !important;
+
+      &:before,
+      &:after {
+        display: none;
+      }
     }
   }
 


### PR DESCRIPTION
This PR removes additional styling from children of `.content-editable` to prevent things like the following:
![](https://cl.ly/2l0e2D140R2w/Screen%20Recording%202016-09-15%20at%2011.55%20AM.gif)