### PR TITLE
[CNVS Upgrade] Allow custom close button

### DIFF
--- a/src/Modal/ModalContents.js
+++ b/src/Modal/ModalContents.js
@@ -218,20 +218,16 @@ class ModalContents extends Util.mixin(BindMixin, KeyDownMixin) {
 
   getCloseButton() {
     let props = this.props;
-    if (!props.showCloseButton) {
-      return null;
+
+    if (props.closeButton) {
+      return (
+        <button className={props.closeButtonClass} onClick={this.closeModal}>
+          {props.closeButton}
+        </button>
+      );
     }
 
-    return (
-      <a
-        className={props.closeButtonClass}
-        onClick={this.closeModal}>
-        <span className={props.closeTitleClass}>
-          Close
-        </span>
-        <i className={props.closeIconClass}></i>
-      </a>
-    );
+    return null;
   }
 
   getHeader() {
@@ -374,7 +370,6 @@ ModalContents.defaultProps = {
   maxHeightPercentage: 0.6,
   onClose: () => {},
   open: false,
-  showCloseButton: false,
   showHeader: false,
   showFooter: false,
   subHeader: null,
@@ -396,8 +391,6 @@ ModalContents.defaultProps = {
   backdropClass: 'modal-backdrop',
   bodyClass: 'modal-body',
   closeButtonClass: 'modal-close',
-  closeIconClass: 'modal-close-icon icon icon-mini icon-mini-white icon-close',
-  closeTitleClass: 'modal-close-title',
   footerClass: 'modal-footer',
   footerContainerClass: 'container',
   headerClass: 'modal-header',
@@ -409,6 +402,8 @@ ModalContents.defaultProps = {
 
 ModalContents.propTypes = {
   children: PropTypes.node,
+  // Appends a close button to the modal if provided.
+  closeButton: PropTypes.node,
   // Allow closing of modal when click happens outside modal. Defaults to true.
   closeByBackdropClick: PropTypes.bool,
   // Allow resize of modal to fit screen. Defaults to true.
@@ -421,8 +416,6 @@ ModalContents.propTypes = {
   onClose: PropTypes.func,
   // True if modal is open, false otherwise.
   open: PropTypes.bool,
-  // Set true to show explicit close button. Defaults to false.
-  showCloseButton: PropTypes.bool,
   // Set true to show header. Defaults to false.
   showHeader: PropTypes.bool,
   // Set true to show footer. Defaults to false.
@@ -457,8 +450,6 @@ ModalContents.propTypes = {
   backdropClass: PropTypes.string,
   bodyClass: PropTypes.string,
   closeButtonClass: PropTypes.string,
-  closeIconClass: PropTypes.string,
-  closeTitleClass: PropTypes.string,
   footerClass: PropTypes.string,
   footerContainerClass: PropTypes.string,
   headerClass: PropTypes.string,

--- a/src/Modal/ModalContents.js
+++ b/src/Modal/ModalContents.js
@@ -220,11 +220,7 @@ class ModalContents extends Util.mixin(BindMixin, KeyDownMixin) {
     let props = this.props;
 
     if (props.closeButton) {
-      return (
-        <button className={props.closeButtonClass} onClick={this.closeModal}>
-          {props.closeButton}
-        </button>
-      );
+      return props.closeButton;
     }
 
     return null;
@@ -402,7 +398,7 @@ ModalContents.defaultProps = {
 
 ModalContents.propTypes = {
   children: PropTypes.node,
-  // Appends a close button to the modal if provided.
+  // Appends whatever value is provided as a close button.
   closeButton: PropTypes.node,
   // Allow closing of modal when click happens outside modal. Defaults to true.
   closeByBackdropClick: PropTypes.bool,

--- a/src/Modal/__tests__/ModalContents-test.js
+++ b/src/Modal/__tests__/ModalContents-test.js
@@ -187,7 +187,7 @@ describe('ModalContents', function () {
 
     it('should return a button if closeButton is provided', function () {
       var instance = TestUtils.renderIntoDocument(
-        <ModalContents closeButton={'Close'} />
+        <ModalContents closeButton={<button>Close</button>} />
       );
 
       var closeButton = instance.getCloseButton();

--- a/src/Modal/__tests__/ModalContents-test.js
+++ b/src/Modal/__tests__/ModalContents-test.js
@@ -179,15 +179,15 @@ describe('ModalContents', function () {
   describe('#getCloseButton', function () {
     it('should not return a button if disabled', function () {
       var instance = TestUtils.renderIntoDocument(
-        <ModalContents showCloseButton={false} />
+        <ModalContents />
       );
 
       expect(instance.getCloseButton()).toEqual(null);
     });
 
-    it('should return a button if enabled', function () {
+    it('should return a button if closeButton is provided', function () {
       var instance = TestUtils.renderIntoDocument(
-        <ModalContents showCloseButton={true} />
+        <ModalContents closeButton={'Close'} />
       );
 
       var closeButton = instance.getCloseButton();


### PR DESCRIPTION
This PR allows users of the `Modal` to pass an element to use for a close button.

Previously there was a boolean property, `showCloseButton`, which rendered a specific set of nodes. Now, there is a `closeButton` prop which will cause a render of a `button` element with the provided node as its child.