### PR TITLE
[CNVS Upgrade] Remove Confirm modal's scrollContainerClass prop assignment

### DIFF
--- a/src/Confirm/Confirm.js
+++ b/src/Confirm/Confirm.js
@@ -51,12 +51,8 @@ class Confirm extends React.Component {
         showCloseButton={false}
         showFooter={true}
         footer={this.getButtons()}
-        scrollContainerClass="modal-content-inner container container-pod
-          container-pod-short flush-bottom"
-        titleClass="modal-header-title text-align-center flush-top
-          flush-bottom"
-        {...props}
-        >
+        titleClass="modal-header-title text-align-center flush-top flush-bottom"
+        {...props}>
         {this.props.children}
       </Modal>
     );


### PR DESCRIPTION
This PR just removes the `scrollContainerClass` prop because it is not necessary.