### PR TITLE
[CNVS Upgrade] Refactor modal height logic

### DIFF
--- a/docs/src/Modal/index.js
+++ b/docs/src/Modal/index.js
@@ -55,10 +55,11 @@ class ModalExample extends React.Component {
                 </button>
                 <Modal open={this.state.open}
                   footer={this.getModalFooter()}
+                  showFooter={true}
                   showHeader={true}
                   onClose={this.handleModalClose}
                   size="large"
-                  titleText="Modal">
+                  header={<h5 className="modal-header-title flush">Modal</h5>}>
                   <div>
                     <div className="container-pod">
                       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nisl dolor, finibus vel egestas et, scelerisque placerat quam.Etiam purus mauris, tempor vel lorem vitae, finibus semper tortor. Nulla nisi nisl, tempus vitae risus ut, gravida elementum purus.Cras scelerisque quis velit at aliquet. Aenean congue faucibus magna nec pellentesque. Nulla facilisi. Etiam feugiat consequat metus,eget consectetur erat sollicitudin in. Maecenas posuere lorem lorem, eu porttitor leo fermentum at. Phasellus volutpat,neque at faucibus dapibus, odio quam molestie lorem, vel gravida lectus diam sit amet neque. Cras ultricies auctor diam,a varius massa eleifend quis. Nulla nec rhoncus odio
@@ -127,7 +128,7 @@ class ModalExample extends React.Component {
           showFooter={true}
           onClose={this.handleModalClose}
           size="large"
-          titleText="Modal">
+          header={<h5 className="modal-header-title flush">Modal</h5>}>
           <div>
             Words words words
           </div>

--- a/docs/src/Modal/index.js
+++ b/docs/src/Modal/index.js
@@ -53,13 +53,13 @@ class ModalExample extends React.Component {
                   onClick={this.handleModalOpen}>
                   Open Modal
                 </button>
-                <Modal open={this.state.open}
+                <Modal
                   footer={this.getModalFooter()}
-                  showFooter={true}
-                  showHeader={true}
+                  header={<h5 className="modal-header-title flush">Modal Header</h5>}
                   onClose={this.handleModalClose}
-                  size="large"
-                  header={<h5 className="modal-header-title flush">Modal</h5>}>
+                  open={this.state.open}
+                  showFooter={true}
+                  showHeader={true}>
                   <div>
                     <div className="container-pod">
                       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nisl dolor, finibus vel egestas et, scelerisque placerat quam.Etiam purus mauris, tempor vel lorem vitae, finibus semper tortor. Nulla nisi nisl, tempus vitae risus ut, gravida elementum purus.Cras scelerisque quis velit at aliquet. Aenean congue faucibus magna nec pellentesque. Nulla facilisi. Etiam feugiat consequat metus,eget consectetur erat sollicitudin in. Maecenas posuere lorem lorem, eu porttitor leo fermentum at. Phasellus volutpat,neque at faucibus dapibus, odio quam molestie lorem, vel gravida lectus diam sit amet neque. Cras ultricies auctor diam,a varius massa eleifend quis. Nulla nec rhoncus odio

--- a/jest/setupEnv.js
+++ b/jest/setupEnv.js
@@ -1,0 +1,5 @@
+// jsdom doesn't have support for requestAnimationFrame so we just make it work.
+global.requestAnimationFrame = function (func) {
+  var args = Array.prototype.slice.call(arguments).slice(1);
+  return func.apply(this, args);
+};

--- a/src/Confirm/Confirm.js
+++ b/src/Confirm/Confirm.js
@@ -51,7 +51,6 @@ class Confirm extends React.Component {
         showCloseButton={false}
         showFooter={true}
         footer={this.getButtons()}
-        titleClass="modal-header-title text-align-center flush-top flush-bottom"
         {...props}>
         {this.props.children}
       </Modal>

--- a/src/Modal/ModalContents.js
+++ b/src/Modal/ModalContents.js
@@ -90,28 +90,31 @@ class ModalContents extends Util.mixin(BindMixin, KeyDownMixin) {
   handleWindowResize() {
     let {props, state} = this;
 
-    // Recalculate the height of the modal if it's open and using Gemini.
-    if (props.open && props.useGemini) {
-      let viewportHeight = DOMUtil.getViewportHeight();
-
-      // If the height of the viewport is getting shorter, or if it's growing
-      // while the height is currently constrained, then we reset the restrained
-      // height to null which will cause the height to be recalculated on the
-      // next render.
-      if (viewportHeight < this.lastViewportHeight
-        || (viewportHeight > this.lastViewportHeight
-          && state.height !== null)) {
-        this.setState({height: null});
-      }
-
-      this.lastViewportHeight = viewportHeight;
+    // Return early if the modal is closed or not using Gemini.
+    if (!props.open || !props.useGemini) {
+      return;
     }
+
+    let viewportHeight = DOMUtil.getViewportHeight();
+
+    // If the height of the viewport is getting shorter, or if it's growing
+    // while the height is currently constrained, then we reset the restrained
+    // height to null which will cause the height to be recalculated on the
+    // next render.
+    if (viewportHeight < this.lastViewportHeight
+      || (viewportHeight > this.lastViewportHeight
+        && state.height !== null)) {
+      this.setState({height: null});
+    }
+
+    this.lastViewportHeight = viewportHeight;
   }
 
   calculateContentHeight() {
-    let innerContentHeight = this.refs.innerContent
-      .getBoundingClientRect().height;
-    let innerContentContainerHeight = this.refs.innerContentContainer
+    let {innerContent, innerContentContainer} = this.refs;
+
+    let innerContentHeight = innerContent.getBoundingClientRect().height;
+    let innerContentContainerHeight = innerContentContainer
       .getBoundingClientRect().height;
 
     if (innerContentHeight > innerContentContainerHeight) {

--- a/src/Modal/ModalContents.js
+++ b/src/Modal/ModalContents.js
@@ -52,7 +52,7 @@ class ModalContents extends Util.mixin(BindMixin, KeyDownMixin) {
 
     // If we don't already know the height of the content, we calculate it.
     if (this.props.open && this.props.useGemini && this.state.height == null) {
-      window.requestAnimationFrame(this.calculateContentHeight);
+      global.requestAnimationFrame(this.calculateContentHeight);
     }
   }
 
@@ -88,8 +88,10 @@ class ModalContents extends Util.mixin(BindMixin, KeyDownMixin) {
   }
 
   handleWindowResize() {
+    let {props, state} = this;
+
     // Recalculate the height of the modal if it's open and using Gemini.
-    if (this.props.open && this.props.useGemini) {
+    if (props.open && props.useGemini) {
       let viewportHeight = DOMUtil.getViewportHeight();
 
       // If the height of the viewport is getting shorter, or if it's growing
@@ -98,7 +100,7 @@ class ModalContents extends Util.mixin(BindMixin, KeyDownMixin) {
       // next render.
       if (viewportHeight < this.lastViewportHeight
         || (viewportHeight > this.lastViewportHeight
-          && this.state.height !== null)) {
+          && state.height !== null)) {
         this.setState({height: null});
       }
 
@@ -122,7 +124,7 @@ class ModalContents extends Util.mixin(BindMixin, KeyDownMixin) {
   }
 
   getCloseButton() {
-    let props = this.props;
+    let {props} = this;
 
     if (props.closeButton) {
       return props.closeButton;
@@ -132,7 +134,7 @@ class ModalContents extends Util.mixin(BindMixin, KeyDownMixin) {
   }
 
   getHeader() {
-    let props = this.props;
+    let {props} = this;
 
     if (props.showHeader === false) {
       return null;
@@ -147,7 +149,8 @@ class ModalContents extends Util.mixin(BindMixin, KeyDownMixin) {
   }
 
   getFooter() {
-    let props = this.props;
+    let {props} = this;
+
     if (props.showFooter === false) {
       return null;
     }
@@ -159,21 +162,23 @@ class ModalContents extends Util.mixin(BindMixin, KeyDownMixin) {
     );
   }
 
-  getModalContent(useGemini) {
+  getModalContent() {
+    let {props, state} = this;
+
     let modalContent = (
-      <div className={this.props.scrollContainerClass} ref="innerContent">
-        {this.props.children}
+      <div className={props.scrollContainerClass} ref="innerContent">
+        {props.children}
       </div>
     );
 
     // If we aren't rendering with Gemini, or we don't know the height of the
     // modal's content, then we render without Gemini.
-    if (!useGemini || this.state.height == null) {
+    if (!props.useGemini || state.height == null) {
       return modalContent;
     }
 
     let geminiContainerStyle = {
-      height: this.state.height
+      height: state.height
     };
 
     return (
@@ -187,14 +192,15 @@ class ModalContents extends Util.mixin(BindMixin, KeyDownMixin) {
   }
 
   getModal() {
-    let props = this.props;
+    let {props, state} = this;
+    let modalStyle = null;
+
     if (!props.open) {
       return null;
     }
 
-    let modalStyle = null;
-    if (this.state.height != null) {
-      modalStyle = {flexBasis: this.state.height};
+    if (state.height != null) {
+      modalStyle = {flexBasis: state.height};
     }
 
     return (
@@ -204,7 +210,7 @@ class ModalContents extends Util.mixin(BindMixin, KeyDownMixin) {
         <div className={props.bodyClass}
           style={modalStyle}
           ref="innerContentContainer">
-          {this.getModalContent(props.useGemini)}
+          {this.getModalContent()}
         </div>
         {this.getFooter()}
       </div>
@@ -212,7 +218,8 @@ class ModalContents extends Util.mixin(BindMixin, KeyDownMixin) {
   }
 
   getBackdrop() {
-    let props = this.props;
+    let {props} = this;
+
     if (!props.open) {
       return null;
     }
@@ -224,7 +231,6 @@ class ModalContents extends Util.mixin(BindMixin, KeyDownMixin) {
 
   render() {
     let {props} = this;
-
     let modalContent = null;
 
     if (props.open) {

--- a/src/Modal/__tests__/ModalContents-test.js
+++ b/src/Modal/__tests__/ModalContents-test.js
@@ -10,12 +10,6 @@ jest.dontMock('../ModalContents');
 var DOMUtil = require('../../Util/DOMUtil');
 var ModalContents = require('../ModalContents');
 
-// We need to add requestAnimationFrame for the component.
-window.requestAnimationFrame = function (func) {
-  var args = Array.prototype.slice.call(arguments).slice(1);
-  return func.apply(this, args);
-};
-
 describe('ModalContents', function () {
 
   beforeEach(function () {

--- a/src/Modal/__tests__/ModalContents-test.js
+++ b/src/Modal/__tests__/ModalContents-test.js
@@ -41,34 +41,6 @@ describe('ModalContents', function () {
       var modal = instance.getModal();
       expect(TestUtils.isElement(modal)).toEqual(true);
     });
-
-    it('should instruct #getModalContent not to render with scrollbar if useGemini is false',
-      function () {
-        var instance = TestUtils.renderIntoDocument(
-          <ModalContents
-            open={true}
-            useGemini={false} />
-        );
-        instance.getModalContent = jasmine.createSpy();
-        instance.getModal();
-
-        expect(instance.getModalContent.mostRecentCall.args[0]).toEqual(false);
-      }
-    );
-
-    it('should instruct #getModalContent to render with scrollbar if useGemini is true',
-      function () {
-        var instance = TestUtils.renderIntoDocument(
-          <ModalContents
-            open={true}
-            useGemini={true} />
-        );
-        instance.getModalContent = jasmine.createSpy();
-        instance.getModal();
-
-        expect(instance.getModalContent).toHaveBeenCalledWith(true);
-      }
-    );
   });
 
   describe('#onClose', function () {

--- a/src/Modal/styles.less
+++ b/src/Modal/styles.less
@@ -12,6 +12,20 @@
     transform: translate(-50%, -50%);
   }
 
+  .modal-body-wrapper {
+    flex: 1 1 auto;
+    min-height: 0;
+    position: relative;
+
+    .container-scrollable {
+      height: 100%;
+      left: 0;
+      position: absolute;
+      top: 0;
+      width: 100%;
+    }
+  }
+
   .modal-backdrop {
     height: 100%;
     left: 0;


### PR DESCRIPTION
This PR aims to simplify the height calculation logic of the `ModalContents` component.

Highlights:
* We use `setState` instead of `forceUpdate` to re-render the modal.
* We calculate the height of the content only when absolutely necessary.
* We make use of `requestAnimationFrame` to help reduce jank.
* The maximum height of the modal is determined by CSS rather than with the `maxHeightPercentage` prop.
* The props API of this component was reduced significantly.
* When `useGemini` is set to `false` (which is now _default_), there is no height calculation done at all.
