### PR TITLE
[CNVS Upgrade] Fix content-editable div styling

### DIFF
--- a/src/Form/styles.less
+++ b/src/Form/styles.less
@@ -241,9 +241,11 @@
   }
 
   .content-editable {
+    display: block;
     height: auto;
     left: 0;
     max-height: 100%;
+    outline: none;
     overflow: auto;
     position: absolute;
     top: 0;


### PR DESCRIPTION
This prevents the following from happening:
![](https://cl.ly/1n2P3l2B1V2f/Screen%20Shot%202016-10-03%20at%204.57.19%20PM.png)