### PR TITLE
Give "textarea" padding on top and bottom

### DIFF
--- a/src/Form/styles.less
+++ b/src/Form/styles.less
@@ -247,6 +247,8 @@
     max-height: 100%;
     outline: none;
     overflow: auto;
+    padding-bottom: 0.35rem;
+    padding-top: 0.35rem;
     position: absolute;
     top: 0;
     white-space: pre-wrap;


### PR DESCRIPTION
This gives proper padding to the `.content-editable` class. It doesn't come with `.form-control` out of the box because the `.form-control` elements have a fixed height. Thanks @Poltergeist for noticing!