### PR TITLE
Toggle display property for caret

### DIFF
--- a/src/Table/styles.less
+++ b/src/Table/styles.less
@@ -15,19 +15,16 @@
   border-left: 0.3em solid transparent;
   border-right: 0.3em solid transparent;
   border-top: 0.45em solid fade(@neutral, 50%);
-  display: inline-block;
+  display: none;
   margin-left: 0.5em;
-  opacity: 0;
   vertical-align: middle;
-  visibility: hidden;
 
   .inverse & {
     border-top: 0.45em solid fade(@white, 50%);
   }
 
   &--visible {
-    opacity: 1;
-    visibility: visible;
+    display: inline-block;
   }
 
   &--asc {


### PR DESCRIPTION
This PR toggles the `display` property rather than `opacity` and `visibility`. This will prevent the caret from affecting layout when it's invisible.

It does mean that center-aligned table headings will jump around when their sorting is toggled. I discussed this solution with @ashenden and he's on board.

![](https://cl.ly/1I072c2N2u1l/Screen%20Recording%202016-11-09%20at%2001.09%20PM.gif)