### PR TITLE
Making modals stack on top of each other when multiple are open

### DIFF
--- a/src/Modal/ModalContents.js
+++ b/src/Modal/ModalContents.js
@@ -1,3 +1,4 @@
+import classNames from 'classnames/dedupe';
 import GeminiScrollbar from 'react-gemini-scrollbar';
 /* eslint-disable no-unused-vars */
 import React, {PropTypes} from 'react';
@@ -238,7 +239,7 @@ class ModalContents extends Util.mixin(BindMixin, KeyDownMixin) {
 
     if (props.open) {
       modalContent = (
-        <div className={props.modalWrapperClass}>
+        <div className={classNames('modal-wrapper', props.modalWrapperClass)}>
           {this.getBackdrop()}
           {this.getModal()}
         </div>
@@ -286,7 +287,6 @@ ModalContents.defaultProps = {
   footerClass: 'modal-footer',
   headerClass: 'modal-header',
   modalClass: 'modal modal-large',
-  modalWrapperClass: 'modal-wrapper',
   scrollContainerClass: 'modal-body'
 };
 

--- a/src/Modal/ModalContents.js
+++ b/src/Modal/ModalContents.js
@@ -286,6 +286,7 @@ ModalContents.defaultProps = {
   footerClass: 'modal-footer',
   headerClass: 'modal-header',
   modalClass: 'modal modal-large',
+  modalWrapperClass: 'modal-wrapper',
   scrollContainerClass: 'modal-body'
 };
 

--- a/src/Modal/styles.less
+++ b/src/Modal/styles.less
@@ -4,12 +4,17 @@
 // * @import (inline) '../../react-gemini-scrollbar/node_modules/gemini-scrollbar/gemini-scrollbar.css';
 
 & when (@modal-enabled) {
+  .modal-wrapper {
+    position: fixed;
+    z-index: @z-index-modal;
+  }
 
   .modal {
     left: 50%;
     position: fixed;
     top: 50%;
     transform: translate(-50%, -50%);
+    z-index: auto;
   }
 
   .modal-body-wrapper {
@@ -32,6 +37,7 @@
     position: fixed;
     top: 0;
     width: 100%;
+    z-index: auto;
   }
 
   .modal-enter,

--- a/src/Modal/styles.less
+++ b/src/Modal/styles.less
@@ -4,6 +4,7 @@
 // * @import (inline) '../../react-gemini-scrollbar/node_modules/gemini-scrollbar/gemini-scrollbar.css';
 
 & when (@modal-enabled) {
+
   .modal-wrapper {
     position: fixed;
     z-index: @z-index-modal;


### PR DESCRIPTION
This PR corrects a bug, where modals would not stack correctly.

Before: | After:
------------ | -------------
![](https://cl.ly/1V2a1A2P0v40/Image%202016-11-15%20at%2016.32.35.png) | ![](https://cl.ly/043540240b1g/Image%202016-11-15%20at%2016.29.54.png)