### PR TITLE
DCOS-11732: Allow passing modal height to ModalContents

### DIFF
--- a/src/Modal/ModalContents.js
+++ b/src/Modal/ModalContents.js
@@ -175,16 +175,20 @@ class ModalContents extends Util.mixin(BindMixin, KeyDownMixin) {
       </div>
     );
 
-    // If we aren't rendering with Gemini, or we don't know the height of the
-    // modal's content, then we render without Gemini.
-    if (!props.useGemini || state.height == null) {
+    // If the consume disables gemini or we don't know the height, then we
+    // don't render with Gemini, unless the consumer is using specifying a
+    // custom height.
+    if ((!props.useGemini || state.height == null)
+      && props.modalHeight == null) {
       return modalContent;
     }
 
     let geminiClasses = classNames('container-scrollable', props.geminiClass);
-    let geminiContainerStyle = {
-      height: state.height
-    };
+    let geminiContainerStyle = {height: state.height};
+
+    if (props.modalHeight) {
+      geminiContainerStyle.height = props.modalHeight;
+    }
 
     return (
       <GeminiScrollbar
@@ -302,6 +306,8 @@ ModalContents.propTypes = {
   footer: PropTypes.object,
   // Optional header.
   header: PropTypes.node,
+  // Specify a custom modal height.
+  modalHeight: PropTypes.string,
   // Optional callback function exected when modal is closed.
   onClose: PropTypes.func,
   // True if modal is open, false otherwise.


### PR DESCRIPTION
This PR allows passing a `modalHeight` prop. When defined, this prop will be assigned to the height of the Gemini wrapper rather than be calculated automatically.

This fixes a bug discovered where the child components would lose their state. Before this PR, the component renders initially without Gemini, then calculates the height of its content. If the height of the content exceeds the container, then it re-renders the content wrapped in Gemini. With this property, we can avoid conditionally rendering the Gemini wrapper.