### PR TITLE
Add block class for tooltip

### DIFF
--- a/src/Tooltip/styles.less
+++ b/src/Tooltip/styles.less
@@ -3,6 +3,10 @@
   position: relative;
 }
 
+.tooltip-block-wrapper {
+  display: block;
+}
+
 .tooltip {
   max-width: 600px;
   opacity: 0;


### PR DESCRIPTION
This gif shows the issue where we need the tooltip to be display `block`, where it is `inline-block`:
![](https://cl.ly/3P2E1C152a3K/Screen%20Recording%202016-11-29%20at%2016.53.gif)