### PR TITLE
Updated CNVS from 1.1.3 to 1.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "babel-preset-react": "6.5.0",
     "babel-runtime": "6.5.0",
     "browser-sync": "2.11.1",
-    "cnvs": "1.1.4",
+    "cnvs": "1.1.5",
     "envify": "3.4.0",
     "eslint": "2.2.0",
     "eslint-plugin-react": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "babel-preset-react": "6.5.0",
     "babel-runtime": "6.5.0",
     "browser-sync": "2.11.1",
-    "cnvs": "1.1.5",
+    "cnvs": "1.1.6",
     "envify": "3.4.0",
     "eslint": "2.2.0",
     "eslint-plugin-react": "4.0.0",

--- a/src/Form/Form.js
+++ b/src/Form/Form.js
@@ -311,9 +311,9 @@ class Form extends Util.mixin(BindMixin) {
     let {props, state} = this;
     let classes = {
       formGroupClass: 'form-group',
-      formGroupErrorClass: 'form-group-error',
+      formGroupErrorClass: 'form-group-danger',
       formRowClass: 'row',
-      helpBlockClass: 'form-help-block',
+      helpBlockClass: 'form-control-feedback',
       inlineIconClass: 'form-element-inline-icon',
       inlineTextClass: 'form-element-inline-text',
       inputClass: 'form-control',


### PR DESCRIPTION
Notable updates:
* Updated .button-flush with directional modifiers
* Fixed disabled buttons of type *-link
* Adjusted background of .form-control and .form-control-toggle
* Updated background style of .form-control style variants
* URI encode inline SVG strings
* Updated styling of `disabled` state for `form-control` component

Full diff here for reviewers: https://github.com/mesosphere/cnvs/compare/4e301e8951b74b7c4d6f959ef255651f7da6a11d...d2eb4d1477a0aab827071db210a7c638f9b3cc45