### PR TITLE
Scroll event not being bubbled in virtual list, ref. DCOS-11781

### DIFF
--- a/src/VirtualList/VirtualList.js
+++ b/src/VirtualList/VirtualList.js
@@ -49,7 +49,8 @@ class VirtualList extends Util.mixin(BindMixin) {
     let state = this.getVirtualState(props);
 
     this.setState(state);
-    props.container.addEventListener('scroll', this.onScroll);
+    // Make sure to bubble scroll event, if there are are other listeners
+    props.container.addEventListener('scroll', this.onScroll, true);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -57,7 +58,8 @@ class VirtualList extends Util.mixin(BindMixin) {
 
     if (this.props.container !== nextProps.container) {
       this.props.container.removeEventListener('scroll', this.onScroll);
-      nextProps.container.addEventListener('scroll', this.onScroll);
+      // Make sure to bubble scroll event, if there are are other listeners
+      nextProps.container.addEventListener('scroll', this.onScroll, true);
     }
 
     let state = this.getVirtualState(nextProps);


### PR DESCRIPTION
---
Same fix as here: https://github.com/mesosphere/reactjs-components/pull/384

---

This PR fixes a bug where the scroll listeners would not bubble to parent elements and would therefore not be able to listen to events higher in the bubble chain.