### PR TITLE
0.16.0-beta.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reactjs-components",
-  "version": "0.16.0-beta.6",
+  "version": "0.16.0-beta.9",
   "description": "React UI Components by Mesosphere",
   "author": {
     "name": "Mesosphere Frontend Team",


### PR DESCRIPTION
Apparently someone had already released beta versions 7 and 8, so I had to jump to 9.