### PR TITLE
Specify c++ version for Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,11 @@
 language: node_js
 node_js:
   - "4"
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - g++-4.8


### PR DESCRIPTION
Build is failing because of C++11 issues, this is what I've found https://github.com/travis-ci/travis-ci/issues/4771

Adding these lines seems to fix the build

```yaml
env:
  - CXX=g++-4.8
addons:
  apt:
    sources:
    - ubuntu-toolchain-r-test
    packages:
    - g++-4.8
```