### PR TITLE
DCOS-14141: Fix modal height calculations in IE11

### DIFF
--- a/src/Modal/ModalContents.js
+++ b/src/Modal/ModalContents.js
@@ -24,6 +24,7 @@ class ModalContents extends Util.mixin(BindMixin) {
   constructor() {
     super(...arguments);
 
+    this.lastConstrainedHeight = null;
     this.state = {
       height: null
     };
@@ -164,6 +165,7 @@ class ModalContents extends Util.mixin(BindMixin) {
     const maxModalHeight = (
       this.lastViewportHeight - MODAL_VERTICAL_INSET_DISTANCE
     );
+
     const totalModalContentHeight = (
       innerContentHeight + headerHeight + footerHeight
     );
@@ -176,12 +178,23 @@ class ModalContents extends Util.mixin(BindMixin) {
     // When the modal's content is too large to fit on the screen, then we need
     // to explicitly set the body's height to its exact pixel value and the
     // modal's height to `100%`.
-    if (totalModalContentHeight >= maxModalHeight) {
+    const shouldConstrainHeight = totalModalContentHeight >= maxModalHeight
+      || this.lastViewportHeight < this.lastConstrainedHeight;
+
+    if (shouldConstrainHeight) {
       const availableContentHeight = modalHeight - headerHeight - footerHeight;
       nextInnerContentContainerHeight = `${availableContentHeight}px`;
       nextModalHeight = '100%';
 
-      if (this.props.useGemini && this.state.height !== availableContentHeight) {
+      // We need to keep track of the largest viewport height that results in a
+      // constrained modal.
+      if (this.lastConstrainedHeight == null
+        || this.lastViewportHeight > this.lastConstrainedHeight) {
+        this.lastConstrainedHeight = this.lastViewportHeight;
+      }
+
+      if (this.props.useGemini
+        && this.state.height !== availableContentHeight) {
         this.setState({height: availableContentHeight});
       }
     }

--- a/src/Modal/ModalContents.js
+++ b/src/Modal/ModalContents.js
@@ -16,6 +16,10 @@ import DOMUtil from '../Util/DOMUtil';
 import Keycodes from '../constants/Keycodes';
 import Util from '../Util/Util';
 
+// This value is used to designate "off-limits" vertical space, so that the
+// modal never comes into contact with the edge of the viewport.
+const MODAL_VERTICAL_INSET_DISTANCE = 48;
+
 class ModalContents extends Util.mixin(BindMixin) {
   constructor() {
     super(...arguments);
@@ -47,7 +51,8 @@ class ModalContents extends Util.mixin(BindMixin) {
     super.componentDidUpdate(...arguments);
 
     // If we don't already know the height of the content, we calculate it.
-    if (this.props.open && this.props.useGemini && this.state.height == null) {
+    if (this.props.open) {
+      this.lastViewportHeight = Math.ceil(DOMUtil.getViewportHeight());
       global.requestAnimationFrame(this.calculateContentHeight);
     }
   }
@@ -98,11 +103,11 @@ class ModalContents extends Util.mixin(BindMixin) {
     let {props, state} = this;
 
     // Return early if the modal is closed or not using Gemini.
-    if (!props.open || !props.useGemini) {
+    if (!props.open) {
       return;
     }
 
-    let viewportHeight = DOMUtil.getViewportHeight();
+    let viewportHeight = Math.ceil(DOMUtil.getViewportHeight());
 
     // If the height of the viewport is getting shorter, or if it's growing
     // while the height is currently constrained, then we reset the restrained
@@ -115,6 +120,7 @@ class ModalContents extends Util.mixin(BindMixin) {
     }
 
     this.lastViewportHeight = viewportHeight;
+    global.requestAnimationFrame(this.calculateContentHeight);
   }
 
   addKeydownListener() {
@@ -126,15 +132,64 @@ class ModalContents extends Util.mixin(BindMixin) {
   }
 
   calculateContentHeight() {
-    let {innerContent, innerContentContainer} = this.refs;
-
-    let innerContentHeight = innerContent.getBoundingClientRect().height;
-    let innerContentContainerHeight = innerContentContainer
-      .getBoundingClientRect().height;
-
-    if (innerContentHeight > innerContentContainerHeight) {
-      this.setState({height: innerContentContainerHeight});
+    // A full screen modal doesn't need to restrict its height.
+    if (this.props.isFullScreen) {
+      return;
     }
+
+    const {
+      footer,
+      gemini,
+      header,
+      modal,
+      innerContent,
+      innerContentContainer
+    } = this.refs;
+
+    let headerHeight = 0;
+    let footerHeight = 0;
+
+    if (header != null) {
+      headerHeight = Math.ceil(header.getBoundingClientRect().height);
+    }
+
+    if (footer != null) {
+      footerHeight = Math.ceil(footer.getBoundingClientRect().height);
+    }
+
+    const modalHeight = Math.ceil(modal.getBoundingClientRect().height);
+    const innerContentHeight = Math.ceil(
+      innerContent.getBoundingClientRect().height
+    );
+    const maxModalHeight = (
+      this.lastViewportHeight - MODAL_VERTICAL_INSET_DISTANCE
+    );
+    const totalModalContentHeight = (
+      innerContentHeight + headerHeight + footerHeight
+    );
+
+    // When the modal's content fits on the screen, both the modal and body
+    // height can be set to `auto` (default).
+    let nextInnerContentContainerHeight = 'auto';
+    let nextModalHeight = 'auto';
+
+    // When the modal's content is too large to fit on the screen, then we need
+    // to explicitly set the body's height to its exact pixel value and the
+    // modal's height to `100%`.
+    if (totalModalContentHeight >= maxModalHeight) {
+      const availableContentHeight = modalHeight - headerHeight - footerHeight;
+      nextInnerContentContainerHeight = `${availableContentHeight}px`;
+      nextModalHeight = '100%';
+
+      if (this.props.useGemini && this.state.height !== availableContentHeight) {
+        this.setState({height: availableContentHeight});
+      }
+    }
+
+    innerContentContainer.style.height = nextInnerContentContainerHeight;
+    modal.style.height = nextModalHeight;
+
+    this.triggerGeminiUpdate();
   }
 
   closeModal() {
@@ -159,7 +214,7 @@ class ModalContents extends Util.mixin(BindMixin) {
     }
 
     return (
-      <div className={props.headerClass}>
+      <div className={props.headerClass} ref="header">
         {props.header}
         {props.subHeader}
       </div>
@@ -174,7 +229,7 @@ class ModalContents extends Util.mixin(BindMixin) {
     }
 
     return (
-      <div className={props.footerClass}>
+      <div className={props.footerClass} ref="footer">
         {props.footer}
       </div>
     );
@@ -208,6 +263,7 @@ class ModalContents extends Util.mixin(BindMixin) {
       <GeminiScrollbar
         autoshow={false}
         className={geminiClasses}
+        ref="gemini"
         style={geminiContainerStyle}>
         {modalContent}
       </GeminiScrollbar>
@@ -216,14 +272,14 @@ class ModalContents extends Util.mixin(BindMixin) {
 
   getModal() {
     let {props, state} = this;
-    let modalStyle = null;
+    let modalBodyStyle = {};
 
     if (!props.open) {
       return null;
     }
 
     if (state.height != null) {
-      modalStyle = {flexBasis: state.height};
+      modalBodyStyle.height = state.height;
     }
 
     return (
@@ -231,7 +287,7 @@ class ModalContents extends Util.mixin(BindMixin) {
         {this.getCloseButton()}
         {this.getHeader()}
         <div className={props.bodyClass}
-          style={modalStyle}
+          style={modalBodyStyle}
           ref="innerContentContainer">
           {this.getModalContent()}
         </div>
@@ -250,6 +306,14 @@ class ModalContents extends Util.mixin(BindMixin) {
     return (
       <div className={props.backdropClass} onClick={this.handleBackdropClick} />
     );
+  }
+
+  triggerGeminiUpdate() {
+    const {gemini} = this.refs;
+
+    if (gemini != null && gemini.scrollbar != null) {
+      gemini.scrollbar.update();
+    }
   }
 
   render() {
@@ -285,6 +349,7 @@ ModalContents.defaultProps = {
   closeByBackdropClick: true,
   footer: null,
   header: null,
+  isFullScreen: false,
   onClose: () => {},
   open: false,
   showHeader: false,
@@ -320,6 +385,8 @@ ModalContents.propTypes = {
   footer: PropTypes.object,
   // Optional header.
   header: PropTypes.node,
+  // Optionally set full screen modal to avoid content height restrictions.
+  isFullScreen: PropTypes.bool,
   // Specify a custom modal height.
   modalHeight: PropTypes.string,
   // Optional callback function exected when modal is closed.

--- a/src/Modal/__tests__/ModalContents-test.js
+++ b/src/Modal/__tests__/ModalContents-test.js
@@ -162,8 +162,14 @@ describe('ModalContents', function () {
     it('should reset the height stored in state to null when the viewport ' +
       'height is shrinking',
       function () {
+        var node = document.createElement('div');
         var instance = TestUtils.renderIntoDocument(
           <ModalContents open={true} useGemini={true} />
+        );
+
+        ReactDOM.render(
+          <ModalContents open={true} useGemini={true} />,
+          node
         );
 
         instance.state.height = 300;
@@ -178,57 +184,6 @@ describe('ModalContents', function () {
 
         expect(instance.lastViewportHeight).toEqual(99);
         expect(instance.state.height).toEqual(null);
-      });
-
-    it('should reset the height stored in state to null when the viewport ' +
-      'height is growing and state.height has previously been calculated',
-      function () {
-        var instance = TestUtils.renderIntoDocument(
-          <ModalContents open={true} useGemini={true} />
-        );
-
-        // The first call returns 100.
-        instance.handleWindowResize();
-        expect(instance.state.height).toEqual(null);
-        // The second call returns 99, so the viewport is shrinking and
-        // state.height should be reset to null.
-        instance.handleWindowResize();
-        expect(instance.state.height).toEqual(null);
-        // The third call returns 101, so the viewport height is growing, but
-        // state.height should already be null.
-        instance.handleWindowResize();
-        expect(instance.state.height).toEqual(null);
-        expect(instance.lastViewportHeight).toEqual(101);
-        // We explicitly set state to 300 so that the next resize handler call
-        // will trigger setState.
-        instance.state.height = 300;
-        // The fourth call returns 102, so the viewport height is growing, and
-        // state.height is not null, so the fourth call should trigger a setState
-        // with the height as null.
-        instance.handleWindowResize();
-        expect(instance.state.height).toEqual(null);
-      });
-  });
-
-  describe('#calculateContentHeight', function () {
-    it('sets state.height to the height of the innerContentContainer if ' +
-      'innerContentHeight is larger than innerContentContainerHeight',
-      function () {
-        var instance = TestUtils.renderIntoDocument(
-          <ModalContents open={true} useGemini={true} />
-        );
-
-        instance.refs.innerContent.getBoundingClientRect = function () {
-          return {height: 400};
-        };
-
-        instance.refs.innerContentContainer.getBoundingClientRect = function () {
-          return {height: 200};
-        };
-
-        instance.calculateContentHeight();
-
-        expect(instance.state.height).toEqual(200);
       });
   });
 


### PR DESCRIPTION
This PR fixes the modal height calculations for IE11. Here's a gif!

Before:
![](https://cl.ly/0D2w1F0q1z2A/Screen%20Recording%202017-02-28%20at%2002.53%20PM.gif)

After:
![](https://cl.ly/0H1W0C2b2h1V/Screen%20Recording%202017-02-28%20at%2002.45%20PM.gif)