### PR TITLE
DCOS-14092: Explicitly set dropdown positioning properties to auto

### DIFF
--- a/src/Dropdown/Dropdown.js
+++ b/src/Dropdown/Dropdown.js
@@ -168,9 +168,11 @@ class Dropdown extends Util.mixin(BindMixin) {
       menuDirection = 'up';
       menuPositionStyle.bottom = spaceAroundDropdownButton.bottom
         + spaceAroundDropdownButton.boundingRect.height;
+      menuPositionStyle.top = 'auto';
       height = spaceAroundDropdownButton.top;
     } else {
       menuDirection = 'down';
+      menuPositionStyle.bottom = 'auto';
       menuPositionStyle.top = spaceAroundDropdownButton.top
         + spaceAroundDropdownButton.boundingRect.height;
       height = spaceAroundDropdownButton.bottom;
@@ -180,9 +182,11 @@ class Dropdown extends Util.mixin(BindMixin) {
       menuPositionStyle.left = spaceAroundDropdownButton.left;
       menuPositionStyle.right = spaceAroundDropdownButton.right;
     } else if (this.props.anchorRight) {
+      menuPositionStyle.left = 'auto';
       menuPositionStyle.right = spaceAroundDropdownButton.right;
     } else {
       menuPositionStyle.left = spaceAroundDropdownButton.left;
+      menuPositionStyle.right = 'auto';
     }
 
     // We assume that 125 pixels is the smallest height we should render.


### PR DESCRIPTION
This PR explicitly sets positioning values to `auto` rather than relying on their default properties. This fixes a bug in IE11 where the dropdown would be rendered flush with the left edge of the viewport.

Before:
![](https://cl.ly/1o2G2y3W3b3F/Screen%20Shot%202017-03-01%20at%2010.47.27%20AM.png)

After:
![](https://cl.ly/0s0b0s1w251z/Screen%20Shot%202017-03-01%20at%2010.43.37%20AM.png)