### PR TITLE
DCOS-12721: Push commit and tags in release script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,37 +36,15 @@ If you want to add a new npm package to `node_modules`:
         npm install [your package] --save-dev
     will add it to devDependencies.
 
-2. Create a synced npm-shrinkwrap.json with devDependencies included
-
-        npm run shrinkwrap
-
 3. Commit to repository
 
-## Creating a new version
-
-1. Change the version within `package.json`
-
-2. Create a synced npm-shrinkwrap.json with devDependencies included
-
-        npm run shrinkwrap
-
-3. Commit to repository and make a PR
-
-4. After PR is merged, the merger will create tags and publish the module
-
-### Creating a tag and publishing
+### Publishing a new Release
 
 1. Make sure you are on `master` branch and have pulled the latest changes.
 
-2. Create the tag ([here's a guide](https://git-scm.com/book/en/v2/Git-Basics-Tagging#Annotated-Tags)).
+2. Now do the release (there is an npm command for this):
 
-3. Push the new tag to github:
-
-        git push --tags
-
-4. Now do the release (there is an npm command for this):
-
-        npm run release
+        npm run release:[<newversion> | major | minor | patch | premajor | preminor | prepatch]
 
 After this you can pull down the latest module version from npm.
 
@@ -74,9 +52,12 @@ After this you can pull down the latest module version from npm.
 
 1. Make sure you are on `master` branch and have pulled the latest changes.
 
-2. Run the `release-beta` NPM script:
+2. Run the `release:beta` NPM script:
 
-        npm run release-beta
+        npm run release:prerelease
+  or
+
+        npm run release:beta
 
 ## Making a PR
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reactjs-components",
-  "version": "0.16.0-beta.10",
+  "version": "0.16.0-beta.11",
   "description": "React UI Components by Mesosphere",
   "author": {
     "name": "Mesosphere Frontend Team",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reactjs-components",
-  "version": "0.16.0-beta.11",
+  "version": "0.16.0-beta.12",
   "description": "React UI Components by Mesosphere",
   "author": {
     "name": "Mesosphere Frontend Team",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reactjs-components",
-  "version": "0.16.0-beta.9",
+  "version": "0.16.0-beta.10",
   "description": "React UI Components by Mesosphere",
   "author": {
     "name": "Mesosphere Frontend Team",

--- a/package.json
+++ b/package.json
@@ -79,11 +79,18 @@
     "predist-src": "rm -rf ./lib",
     "dist-src": "cp -r ./src ./lib && find ./lib -name '__tests__' -type d -exec rm -r '{}' + && ./node_modules/.bin/babel lib --out-dir lib",
     "livereload": "NODE_ENV='development' ./node_modules/.bin/gulp docs:livereload",
-    "npm-publish": "npm publish ./",
     "test": "jest",
-    "release": "npm run clean && npm run test && ./node_modules/.bin/gulp eslint && ./node_modules/.bin/gulp stylelint && npm run dist-src && npm publish ./",
-    "release-beta": "npm run clean && npm run test && ./node_modules/.bin/gulp eslint && ./node_modules/.bin/gulp stylelint && npm run dist-src && npm version prerelease",
-    "postversion": "npm publish ./ --tag version-$npm_package_version"
+    "release": "npm version -m 'Version %s'",
+    "release:major": "npm run release -- major",
+    "release:minor": "npm run release -- minor",
+    "release:patch": "npm run release -- patch",
+    "release:premajor": "npm run release -- premajor",
+    "release:preminor": "npm run release -- preminor",
+    "release:prepatch": "npm run release -- prepatch",
+    "release:prerelease": "npm run release -- prerelease",
+    "release:beta": "npm run release -- prerelease",
+    "preversion": "npm run clean && npm run test && ./node_modules/.bin/gulp eslint && ./node_modules/.bin/gulp stylelint && npm run dist-src",
+    "postversion": "git push && git push --tags && npm publish ./ --tag version-$npm_package_version && echo \"Successfully released $npm_package_version\""
   },
   "jest": {
     "globals": {


### PR DESCRIPTION
This PR makes it easier for us to create releases and automates the process of committing and pushing tags in addition to previous release steps.

See guide to use here: https://github.com/mesosphere/reactjs-components/blob/623b58b6cdacb5c0344ed8a669506d8f026518f8/CONTRIBUTING.md#publishing-a-new-release