### PR TITLE
fix(react-15): exclude prop types from html attributes

### DIFF
--- a/src/Form/FieldCheckbox.js
+++ b/src/Form/FieldCheckbox.js
@@ -87,13 +87,20 @@ class FieldCheckbox extends FieldRadioButton {
       attributes.indicatorClass
     );
 
+    const htmlAttributes = Util.pick(attributes, [
+      "checked",
+      "className",
+      "disabled",
+      "name"
+    ]);
+
     return (
       <label className={labelClasses} key={index}>
         <input
           onChange={this.handleChange.bind(this, eventName, attributes.name)}
           ref={attributes.name}
           type="checkbox"
-          {...attributes}
+          {...htmlAttributes}
         />
         <span className={indicatorClasses} />
         {this.getItemLabel(attributes)}
@@ -139,7 +146,14 @@ FieldCheckbox.propTypes = {
     React.PropTypes.array,
     React.PropTypes.object,
     React.PropTypes.string
-  ])
+  ]),
+  startValue: React.PropTypes.oneOfType([
+    React.PropTypes.array,
+    React.PropTypes.bool
+  ]),
+  labelClass: React.PropTypes.string,
+  indicatorClasses: React.PropTypes.string,
+  indeterminate: React.PropTypes.bool
 };
 
 module.exports = FieldCheckbox;

--- a/src/Form/FieldInput.js
+++ b/src/Form/FieldInput.js
@@ -152,13 +152,18 @@ class FieldInput extends Util.mixin(BindMixin) {
     const classes = classNames(inputClass, sharedClass);
     attributes = this.bindEvents(attributes);
 
+    const htmlAttributes = Util.exclude(
+      attributes,
+      Object.keys(FieldInput.propTypes)
+    );
+
     if (this.isEditing() || writeType === "input") {
       inputContent = (
         <input
           ref="inputElement"
           className={classes}
           onKeyDown={this.handleKeyDown.bind(this)}
-          {...attributes}
+          {...htmlAttributes}
           value={attributes.startValue}
         />
       );
@@ -166,7 +171,7 @@ class FieldInput extends Util.mixin(BindMixin) {
       inputContent = (
         <span
           ref="inputElement"
-          {...attributes}
+          {...htmlAttributes}
           className={classes}
           onClick={attributes.onFocus}
         >
@@ -283,7 +288,17 @@ FieldInput.propTypes = {
   inlineIconClass: classPropType,
   inlineTextClass: classPropType,
   labelClass: classPropType,
-  sharedClass: classPropType
+  sharedClass: classPropType,
+  fieldType: React.PropTypes.string,
+  currentValue: React.PropTypes.object,
+  maxColumnWidth: React.PropTypes.number,
+  formRowClass: React.PropTypes.string,
+  inputClass: React.PropTypes.string,
+  readClass: React.PropTypes.string,
+  validation: React.PropTypes.func,
+  validationErrorText: React.PropTypes.string,
+  showError: React.PropTypes.string,
+  errorText: React.PropTypes.string
 };
 
 module.exports = FieldInput;

--- a/src/Form/FieldRadioButton.js
+++ b/src/Form/FieldRadioButton.js
@@ -108,12 +108,17 @@ class FieldRadioButton extends Util.mixin(BindMixin) {
       attributes.indicatorClass
     );
 
+    const htmlAttributes = Util.exclude(
+      attributes,
+      Object.keys(FieldRadioButton.propTypes)
+    );
+
     return (
       <label className={labelClasses} key={index}>
         <input
           onChange={this.handleChange.bind(this, eventName, attributes.name)}
           type="radio"
-          {...attributes}
+          {...htmlAttributes}
         />
         <span className={indicatorClasses} />
         {this.getItemLabel(attributes)}

--- a/src/List/List.js
+++ b/src/List/List.js
@@ -11,10 +11,17 @@ class List extends React.Component {
       const key = `${parentIndex}.${childIndex}`;
       childIndex++;
 
+      const htmlAttributes = Util.exclude(item, [
+        "content",
+        "transitionName",
+        "transitionEnterTimeout",
+        "transitionLeaveTimeout"
+      ]);
+
       if (Util.isArrayLike(item.content)) {
         return (
           <ListItem
-            {...Util.exclude(item, ["content"])}
+            {...htmlAttributes}
             key={key}
             tag={item.tag}
             transition={true}
@@ -27,7 +34,7 @@ class List extends React.Component {
         );
       } else {
         return (
-          <ListItem key={key} {...Util.exclude(item, ["content"])}>
+          <ListItem key={key} {...htmlAttributes}>
             {item.content}
           </ListItem>
         );
@@ -42,12 +49,12 @@ class List extends React.Component {
     const Tag = props.tag;
 
     // Uses all passed properties as attributes, excluding propTypes
-    const attributes = Util.exclude(props, Object.keys(List.propTypes));
+    const htmlAttributes = Util.exclude(props, Object.keys(List.propTypes));
 
     if (props.transition) {
       return (
         <ReactCSSTransitionGroup
-          {...attributes}
+          {...htmlAttributes}
           className={props.className}
           component={Tag}
           transitionName={props.transitionName}
@@ -60,7 +67,7 @@ class List extends React.Component {
     }
 
     return (
-      <Tag {...attributes} className={props.className}>
+      <Tag {...htmlAttributes} className={props.className}>
         {this.getListItems(props.content)}
       </Tag>
     );

--- a/src/List/ListItem.js
+++ b/src/List/ListItem.js
@@ -9,13 +9,12 @@ class ListItem extends React.Component {
     const Tag = props.tag;
 
     // Uses all passed properties as attributes, excluding propTypes
-    const attributes = Util.exclude(props, Object.keys(ListItem.propTypes)) || {
-    };
+    const htmlAttributes = Util.exclude(props, Object.keys(ListItem.propTypes));
 
-    if (attributes.transition) {
+    if (props.transition) {
       return (
         <ReactCSSTransitionGroup
-          {...attributes}
+          {...htmlAttributes}
           className={props.className}
           component={props.tag}
         >
@@ -25,7 +24,7 @@ class ListItem extends React.Component {
     }
 
     return (
-      <Tag {...attributes} className={props.className}>
+      <Tag {...htmlAttributes} className={props.className}>
         {props.children}
       </Tag>
     );
@@ -40,7 +39,8 @@ ListItem.defaultProps = {
 ListItem.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
-  tag: PropTypes.string
+  tag: PropTypes.string,
+  transition: PropTypes.bool
 };
 
 module.exports = ListItem;

--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -328,7 +328,8 @@ Tooltip.propTypes = {
   width: React.PropTypes.number,
   wrapperClassName: React.PropTypes.string,
   // Allow the text content to wrap. Default is false.
-  wrapText: React.PropTypes.bool
+  wrapText: React.PropTypes.bool,
+  contentClassName: React.PropTypes.string
 };
 
 module.exports = Tooltip;

--- a/src/VirtualList/VirtualList.js
+++ b/src/VirtualList/VirtualList.js
@@ -8,6 +8,7 @@ import ReactDOM from "react-dom";
 import throttle from "lodash.throttle";
 
 import DOMUtil from "../Util/DOMUtil";
+import Util from "../Util/Util";
 
 const mathMax = Math.max;
 const mathMin = Math.min;
@@ -230,8 +231,13 @@ class VirtualList extends React.Component {
       bottomStyles.display = "none";
     }
 
+    const htmlAttributes = Util.exclude(
+      props,
+      Object.keys(VirtualList.propTypes)
+    );
+
     return (
-      <props.tagName ref="list" {...props}>
+      <props.tagName ref="list" {...htmlAttributes}>
         {props.renderBufferItem(topStyles)}
         {this.getItemsToRender(props, state)}
         {props.renderBufferItem(bottomStyles)}


### PR DESCRIPTION
This PR addresses all the react 15.4.x warnings by filtering the attributes we provide to tags.