### PR TITLE
Upgrade and restructure react dependenceis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install:
   - npm install -g npm@3.9
 install:
   - npm install
-  - npm install react@$REACT_VERSION react-addons-css-transition-group@$REACT_VERSION react-addons-test-utils@$REACT_VERSION react-dom@$REACT_VERSION
+  - ./install_react.sh
 env:
   global:
     - CXX=g++-4.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ env:
   global:
     - CXX=g++-4.8
   matrix:
-    - REACT_VERSION=0.14
     - REACT_VERSION=15.0
     - REACT_VERSION=15.6
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,11 @@ env:
     - CXX=g++-4.8
   matrix:
     - REACT_VERSION=15.0
+    - REACT_VERSION=15.1
+    - REACT_VERSION=15.2
+    - REACT_VERSION=15.3
+    - REACT_VERSION=15.4
+    - REACT_VERSION=15.5
     - REACT_VERSION=15.6
 addons:
   apt:

--- a/docs/src/components/CodeBlock.js
+++ b/docs/src/components/CodeBlock.js
@@ -1,4 +1,5 @@
 import classnames from "classnames/dedupe";
+import PropTypes from "prop-types";
 import React from "react";
 
 class CodeBlock extends React.Component {
@@ -22,10 +23,10 @@ class CodeBlock extends React.Component {
   }
 }
 
-const classPropTypes = React.PropTypes.oneOfType([
-  React.PropTypes.array,
-  React.PropTypes.object,
-  React.PropTypes.string
+const classPropTypes = PropTypes.oneOfType([
+  PropTypes.array,
+  PropTypes.object,
+  PropTypes.string
 ]);
 
 CodeBlock.defaultProps = {
@@ -33,8 +34,8 @@ CodeBlock.defaultProps = {
 };
 
 CodeBlock.propTypes = {
-  children: React.PropTypes.node.isRequired,
-  language: React.PropTypes.string,
+  children: PropTypes.node.isRequired,
+  language: PropTypes.string,
   panelInnerClassNames: classPropTypes,
   preClassNames: classPropTypes
 };

--- a/docs/src/components/CodeBlockWrapper.js
+++ b/docs/src/components/CodeBlockWrapper.js
@@ -1,5 +1,6 @@
 import classnames from "classnames/dedupe";
 import React from "react";
+import PropTypes from "prop-types";
 
 class CodeBlockWrapper extends React.Component {
   render() {
@@ -17,11 +18,11 @@ class CodeBlockWrapper extends React.Component {
 }
 
 CodeBlockWrapper.propTypes = {
-  children: React.PropTypes.node.isRequired,
-  panelClassNames: React.PropTypes.oneOfType([
-    React.PropTypes.array,
-    React.PropTypes.object,
-    React.PropTypes.string
+  children: PropTypes.node.isRequired,
+  panelClassNames: PropTypes.oneOfType([
+    PropTypes.array,
+    PropTypes.object,
+    PropTypes.string
   ])
 };
 

--- a/docs/src/components/ComponentExample.js
+++ b/docs/src/components/ComponentExample.js
@@ -1,5 +1,6 @@
 import classnames from "classnames/dedupe";
 import React from "react";
+import PropTypes from "prop-types";
 
 class ComponentExample extends React.Component {
   render() {
@@ -14,11 +15,11 @@ class ComponentExample extends React.Component {
 }
 
 ComponentExample.propTypes = {
-  children: React.PropTypes.node.isRequired,
-  classNames: React.PropTypes.oneOfType([
-    React.PropTypes.array,
-    React.PropTypes.object,
-    React.PropTypes.string
+  children: PropTypes.node.isRequired,
+  classNames: PropTypes.oneOfType([
+    PropTypes.array,
+    PropTypes.object,
+    PropTypes.string
   ])
 };
 

--- a/docs/src/components/ComponentExampleWrapper.js
+++ b/docs/src/components/ComponentExampleWrapper.js
@@ -1,5 +1,6 @@
 import classnames from "classnames/dedupe";
 import React from "react";
+import PropTypes from "prop-types";
 
 class ComponentExampleWrapper extends React.Component {
   render() {
@@ -17,11 +18,11 @@ class ComponentExampleWrapper extends React.Component {
 }
 
 ComponentExampleWrapper.propTypes = {
-  children: React.PropTypes.node.isRequired,
-  className: React.PropTypes.oneOfType([
-    React.PropTypes.array,
-    React.PropTypes.object,
-    React.PropTypes.string
+  children: PropTypes.node.isRequired,
+  className: PropTypes.oneOfType([
+    PropTypes.array,
+    PropTypes.object,
+    PropTypes.string
   ])
 };
 

--- a/docs/src/components/ComponentWrapper.js
+++ b/docs/src/components/ComponentWrapper.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 
 import IconCode from "./icons/IconCode";
 
@@ -21,9 +22,9 @@ class ComponentWrapper extends React.Component {
 }
 
 ComponentWrapper.propTypes = {
-  children: React.PropTypes.node.isRequired,
-  srcURI: React.PropTypes.string.isRequired,
-  title: React.PropTypes.string.isRequired
+  children: PropTypes.node.isRequired,
+  srcURI: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired
 };
 
 module.exports = ComponentWrapper;

--- a/docs/src/components/PropertiesAPIBlock.js
+++ b/docs/src/components/PropertiesAPIBlock.js
@@ -1,5 +1,6 @@
 import classNames from "classnames";
 import React from "react";
+import PropTypes from "prop-types";
 
 import CodeBlock from "./CodeBlock";
 import CodeBlockWrapper from "./CodeBlockWrapper";
@@ -52,11 +53,8 @@ class PropertiesAPIBlock extends Util.mixin(BindMixin) {
 }
 
 PropertiesAPIBlock.propTypes = {
-  toggleClasses: React.PropTypes.oneOfType([
-    React.PropTypes.string,
-    React.PropTypes.object
-  ]),
-  propTypesBlock: React.PropTypes.string.isRequired
+  toggleClasses: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+  propTypesBlock: PropTypes.string.isRequired
 };
 
 module.exports = PropertiesAPIBlock;

--- a/docs/src/components/icons/IconCode.js
+++ b/docs/src/components/icons/IconCode.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 
 class IconCode extends React.Component {
   render() {
@@ -22,7 +23,7 @@ IconCode.defaultProps = {
 };
 
 IconCode.propTypes = {
-  className: React.PropTypes.string
+  className: PropTypes.string
 };
 
 module.exports = IconCode;

--- a/install_react.sh
+++ b/install_react.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ "$REACT_VERSION" = "15.0" ]; then npm install react@15.0 react-dom@15.0 react-addons-test-utils@15.0; fi
+if [ "$REACT_VERSION" = "15.1" ]; then npm install react@15.1 react-dom@15.1 react-addons-test-utils@15.1; fi
+if [ "$REACT_VERSION" = "15.2" ]; then npm install react@15.2 react-dom@15.2 react-addons-test-utils@15.2; fi
+if [ "$REACT_VERSION" = "15.3" ]; then npm install react@15.3 react-dom@15.3 react-addons-test-utils@15.3; fi
+if [ "$REACT_VERSION" = "15.4" ]; then npm install react@15.4 react-dom@15.4 react-addons-test-utils@15.4; fi
+if [ "$REACT_VERSION" = "15.5" ]; then npm install react@15.5 react-dom@15.5 react-addons-test-utils@15.5; fi
+if [ "$REACT_VERSION" = "15.6" ]; then npm install react@15.6 react-dom@15.6; fi

--- a/package.json
+++ b/package.json
@@ -16,10 +16,7 @@
     "url": "https://github.com/mesosphere/reactjs-components"
   },
   "license": "Apache-2.0",
-  "files": [
-    "main.js",
-    "lib"
-  ],
+  "files": ["main.js", "lib"],
   "main": "main.js",
   "dependencies": {
     "classnames": "2.2.3",
@@ -65,8 +62,8 @@
     "node-libs-browser": "1.0.0",
     "prettier": "1.2.2",
     "react": "15.0.x || 15.6.x",
-    "react-addons-css-transition-group": "15.0.x || 15.6.x",
     "react-addons-test-utils": "15.5.0",
+    "react-transition-group": "1.2.x",
     "react-dom": "15.0.x || 15.6.x",
     "react-gemini-scrollbar": "2.1.x",
     "react-addons-test-utils": "15.5.0",
@@ -81,7 +78,7 @@
   "peerDependencies": {
     "cnvs": "1.1.x",
     "react": "15.0.x || 15.6.x",
-    "react-addons-css-transition-group": "15.0.x || 15.6.x",
+    "react-transition-group": "1.2.x",
     "react-gemini-scrollbar": "2.1.x"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -64,10 +64,10 @@
     "less-color-lighten": "0.0.1",
     "node-libs-browser": "1.0.0",
     "prettier": "1.2.2",
-    "react": "0.14.x || 15.0.x || 15.6.x",
-    "react-addons-css-transition-group": "0.14.x || 15.0.x || 15.6.x",
-    "react-addons-test-utils": "0.14.x || 15.0.x || 15.6.x",
-    "react-dom": "0.14.x || 15.0.x || 15.6.x",
+    "react": "15.0.x || 15.6.x",
+    "react-addons-css-transition-group": "15.0.x || 15.6.x",
+    "react-addons-test-utils": "15.5.0",
+    "react-dom": "15.0.x || 15.6.x",
     "react-gemini-scrollbar": "2.1.x",
     "source-map-loader": "0.1.5",
     "stylelint": "7.10.1",
@@ -79,8 +79,8 @@
   },
   "peerDependencies": {
     "cnvs": "1.1.x",
-    "react": "0.14.x || 15.0.x || 15.6.x",
-    "react-addons-css-transition-group": "0.14.x || 15.0.x || 15.6.x",
+    "react": "15.0.x || 15.6.x",
+    "react-addons-css-transition-group": "15.0.x || 15.6.x",
     "react-gemini-scrollbar": "2.1.x"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "react-addons-test-utils": "15.5.0",
     "react-dom": "15.0.x || 15.6.x",
     "react-gemini-scrollbar": "2.1.x",
+    "react-addons-test-utils": "15.5.0",
     "source-map-loader": "0.1.5",
     "stylelint": "7.10.1",
     "stylelint-config-dcos": "0.0.3",

--- a/package.json
+++ b/package.json
@@ -61,10 +61,9 @@
     "less-color-lighten": "0.0.1",
     "node-libs-browser": "1.0.0",
     "prettier": "1.2.2",
-    "react": "15.0.x || 15.6.x",
-    "react-addons-test-utils": "15.5.0",
+    "react": "^15.0.0",
     "react-transition-group": "1.2.x",
-    "react-dom": "15.0.x || 15.6.x",
+    "react-dom": "^15.0.0",
     "react-gemini-scrollbar": "2.1.x",
     "react-addons-test-utils": "15.5.0",
     "source-map-loader": "0.1.5",
@@ -77,7 +76,7 @@
   },
   "peerDependencies": {
     "cnvs": "1.1.x",
-    "react": "15.0.x || 15.6.x",
+    "react": "^15.0.0",
     "react-transition-group": "1.2.x",
     "react-gemini-scrollbar": "2.1.x"
   },

--- a/package.json
+++ b/package.json
@@ -16,11 +16,15 @@
     "url": "https://github.com/mesosphere/reactjs-components"
   },
   "license": "Apache-2.0",
-  "files": ["main.js", "lib"],
+  "files": [
+    "main.js",
+    "lib"
+  ],
   "main": "main.js",
   "dependencies": {
     "classnames": "2.2.3",
-    "lodash.throttle": "4.1.1"
+    "lodash.throttle": "4.1.1",
+    "prop-types": "^15.6.0"
   },
   "devDependencies": {
     "babel-cli": "6.5.1",

--- a/src/Confirm/Confirm.js
+++ b/src/Confirm/Confirm.js
@@ -1,5 +1,6 @@
 import classNames from "classnames";
-import React, { PropTypes } from "react";
+import React from "react";
+import PropTypes from "prop-types";
 
 import Modal from "../Modal/Modal";
 import Util from "../Util/Util";
@@ -82,7 +83,7 @@ Confirm.defaultProps = {
 };
 
 Confirm.propTypes = {
-  children: React.PropTypes.node.isRequired,
+  children: PropTypes.node.isRequired,
 
   open: PropTypes.bool.isRequired,
   disabled: PropTypes.bool,

--- a/src/Confirm/__tests__/Confirm-test.js
+++ b/src/Confirm/__tests__/Confirm-test.js
@@ -1,7 +1,13 @@
 /* eslint-disable no-unused-vars */
 var React = require("react");
 /* eslint-enable no-unused-vars */
-var TestUtils = require("react-addons-test-utils");
+
+var TestUtils;
+if (React.version.match(/15.[0-5]/)) {
+  TestUtils = require("react-addons-test-utils");
+} else {
+  TestUtils = require("react-dom/test-utils");
+}
 
 jest.dontMock("../Confirm.js");
 

--- a/src/Dropdown/Dropdown.js
+++ b/src/Dropdown/Dropdown.js
@@ -1,6 +1,7 @@
 import classNames from "classnames";
 import GeminiScrollbar from "react-gemini-scrollbar";
 import React from "react";
+import PropTypes from "prop-types";
 import { CSSTransitionGroup } from "react-transition-group";
 import ReactDOM from "react-dom";
 
@@ -441,79 +442,61 @@ Dropdown.defaultProps = {
 
 Dropdown.propTypes = {
   // When true, anchors the dropdown to the right of the trigger.
-  anchorRight: React.PropTypes.bool,
+  anchorRight: PropTypes.bool,
   // When set it will always set this property as the selected ID.
   // Notice: This property will override the initialID
-  persistentID: React.PropTypes.oneOfType([
-    React.PropTypes.string,
-    React.PropTypes.number
-  ]),
+  persistentID: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   // The items to display in the dropdown.
-  items: React.PropTypes.arrayOf(
-    React.PropTypes.shape({
+  items: PropTypes.arrayOf(
+    PropTypes.shape({
       // An optional classname for the menu item.
-      className: React.PropTypes.string,
+      className: PropTypes.string,
       // A required ID for each item
-      id: React.PropTypes.oneOfType([
-        React.PropTypes.string,
-        React.PropTypes.number
-      ]).isRequired,
+      id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
       // The HTML (or text) to render for the list item.
-      html: React.PropTypes.oneOfType([
-        React.PropTypes.string,
-        React.PropTypes.object
-      ]),
+      html: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
       // Whether or not the user can choose the item.
-      selectable: React.PropTypes.bool,
+      selectable: PropTypes.bool,
       // The HTML (or text) to display when the option is selected. If this is
       // not provided, the value for the `html` property will be used.
-      selectedHtml: React.PropTypes.oneOfType([
-        React.PropTypes.string,
-        React.PropTypes.object
-      ])
+      selectedHtml: PropTypes.oneOfType([PropTypes.string, PropTypes.object])
     })
   ).isRequired,
   // The ID of the item that should be selected initially.
-  initialID: React.PropTypes.oneOfType([
-    React.PropTypes.string,
-    React.PropTypes.number
-  ]),
+  initialID: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   // When true, the width of the dropdown will match the width of the button.
-  matchButtonWidth: React.PropTypes.bool,
+  matchButtonWidth: PropTypes.bool,
   // An optional callback when an item is selected. Will receive an argument
   // containing the selected item as it was supplied via the items array.
-  onItemSelection: React.PropTypes.func,
+  onItemSelection: PropTypes.func,
   // The nearest scrolling DOMNode that contains the dropdown. Defaults to
   // window. Also accepts a string, treated as a selector for the node.
-  scrollContainer: React.PropTypes.oneOfType([
-    React.PropTypes.object,
-    React.PropTypes.string
-  ]),
+  scrollContainer: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
   // Will attach the scroll handler to the the direct parent of scrollContainer
   // if it matches this selector. Defaults to null.
-  scrollContainerParentSelector: React.PropTypes.string,
+  scrollContainerParentSelector: PropTypes.string,
   // Optional transition on the dropdown menu. Must be accompanied
   // by an animation or transition in CSS.
-  transition: React.PropTypes.bool,
+  transition: PropTypes.bool,
   // The prefix of the transition classnames.
-  transitionName: React.PropTypes.string,
+  transitionName: PropTypes.string,
   // Transition lengths
-  transitionEnterTimeout: React.PropTypes.number,
-  transitionLeaveTimeout: React.PropTypes.number,
+  transitionEnterTimeout: PropTypes.number,
+  transitionLeaveTimeout: PropTypes.number,
   // Option to use Gemini scrollbar. Defaults to true.
-  useGemini: React.PropTypes.bool,
+  useGemini: PropTypes.bool,
 
   // Classes:
   // Classname for the element that ther user interacts with to open menu.
-  buttonClassName: React.PropTypes.string,
+  buttonClassName: PropTypes.string,
   // Classname for the dropdown menu wrapper.
-  dropdownMenuClassName: React.PropTypes.string,
+  dropdownMenuClassName: PropTypes.string,
   // Classname for the dropdown list wrapper.
-  dropdownMenuListClassName: React.PropTypes.string,
+  dropdownMenuListClassName: PropTypes.string,
   // Classname for the dropdown list item.
-  dropdownMenuListItemClassName: React.PropTypes.string,
+  dropdownMenuListItemClassName: PropTypes.string,
   // Classname for the element that wraps the entire component.
-  wrapperClassName: React.PropTypes.string
+  wrapperClassName: PropTypes.string
 };
 
 module.exports = Dropdown;

--- a/src/Dropdown/Dropdown.js
+++ b/src/Dropdown/Dropdown.js
@@ -1,7 +1,7 @@
 import classNames from "classnames";
 import GeminiScrollbar from "react-gemini-scrollbar";
 import React from "react";
-import ReactCSSTransitionGroup from "react-addons-css-transition-group";
+import { CSSTransitionGroup } from "react-transition-group";
 import ReactDOM from "react-dom";
 
 import BindMixin from "../Mixin/BindMixin";
@@ -18,7 +18,9 @@ class Dropdown extends Util.mixin(BindMixin) {
       "handleExternalClick",
       "handleKeyDown",
       "handleMenuRender",
-      "handleWrapperBlur"
+      "handleWrapperBlur",
+      "setDropdownMenuRef",
+      "setDropdownWrapperRef"
     ];
   }
 
@@ -147,10 +149,10 @@ class Dropdown extends Util.mixin(BindMixin) {
     let menuDirection = this.state.menuDirection;
     const menuPositionStyle = {};
     const spaceAroundDropdownButton = DOMUtil.getNodeClearance(
-      this.refs.dropdownWrapper
+      this.dropdownWrapperRef
     );
     const menuHeight =
-      this.state.menuHeight || this.refs.dropdownMenu.firstChild.clientHeight;
+      this.state.menuHeight || this.dropdownMenuRef.firstChild.clientHeight;
     const isMenuTallerThanBottom =
       menuHeight > spaceAroundDropdownButton.bottom;
     const isMenuTallerThanTop = menuHeight > spaceAroundDropdownButton.top;
@@ -216,7 +218,7 @@ class Dropdown extends Util.mixin(BindMixin) {
     // position to a default state to trigger its recalculation on the next
     // render.
     if (this.state.menuHeight == null) {
-      const buttonPosition = this.refs.dropdownWrapper.getBoundingClientRect();
+      const buttonPosition = this.dropdownWrapperRef.getBoundingClientRect();
 
       state.menuDirection = "down";
       state.menuPositionStyle = {
@@ -302,6 +304,14 @@ class Dropdown extends Util.mixin(BindMixin) {
     return this.props.persistentID || this.state.selectedID;
   }
 
+  setDropdownMenuRef(element) {
+    this.dropdownMenuRef = element;
+  }
+
+  setDropdownWrapperRef(element) {
+    this.dropdownWrapperRef = element;
+  }
+
   render() {
     // Set a key based on the menu height so that React knows to keep the
     // the DOM element around while we are measuring it.
@@ -364,7 +374,7 @@ class Dropdown extends Util.mixin(BindMixin) {
         <span
           className={dropdownMenuClassSet}
           role="menu"
-          ref="dropdownMenu"
+          ref={this.setDropdownMenuRef}
           style={state.menuPositionStyle}
         >
           <div className={props.dropdownMenuListClassName}>
@@ -384,13 +394,13 @@ class Dropdown extends Util.mixin(BindMixin) {
 
     if (props.transition) {
       dropdownMenu = (
-        <ReactCSSTransitionGroup
+        <CSSTransitionGroup
           transitionName={transitionName}
           transitionEnterTimeout={props.transitionEnterTimeout}
           transitionLeaveTimeout={props.transitionLeaveTimeout}
         >
           {dropdownMenu}
-        </ReactCSSTransitionGroup>
+        </CSSTransitionGroup>
       );
     }
 
@@ -399,12 +409,11 @@ class Dropdown extends Util.mixin(BindMixin) {
         className={wrapperClassSet}
         tabIndex="1"
         onBlur={this.handleWrapperBlur}
-        ref="dropdownWrapper"
+        ref={this.setDropdownWrapperRef}
       >
         <button
           className={props.buttonClassName}
           onClick={this.handleMenuToggle}
-          ref="button"
           type="button"
         >
           {this.getSelectedHtml(this.getSelectedID(), items)}

--- a/src/Dropdown/__tests__/Dropdown-test.js
+++ b/src/Dropdown/__tests__/Dropdown-test.js
@@ -122,7 +122,12 @@ describe("Dropdown", function() {
       />
     );
 
-    var disabledState = ReactDOM.findDOMNode(instance.refs.button).disabled;
+    const button = TestUtils.findRenderedDOMComponentWithClass(
+      instance,
+      "button dropdown-toggle"
+    );
+
+    var disabledState = ReactDOM.findDOMNode(button).disabled;
     expect(disabledState).toEqual(true);
   });
 

--- a/src/Dropdown/__tests__/Dropdown-test.js
+++ b/src/Dropdown/__tests__/Dropdown-test.js
@@ -44,7 +44,11 @@ describe("Dropdown", function() {
 
   it("should display a dropdown menu when the button is clicked", function() {
     // Click on the dropdown button to open the menu
-    TestUtils.Simulate.click(this.instance.refs.button);
+    const button = TestUtils.findRenderedDOMComponentWithClass(
+      this.instance,
+      "button dropdown-toggle"
+    );
+    TestUtils.Simulate.click(button);
     // Find the dropdown menu in the DOM
     var dropdownMenu = document.body.querySelectorAll(".dropdown-menu");
     expect(Array.prototype.slice.call(dropdownMenu).length).toEqual(1);
@@ -73,7 +77,11 @@ describe("Dropdown", function() {
 
   it("should call the callback when selecting a selectable item", function() {
     // Click on the dropdown button to open the menu
-    TestUtils.Simulate.click(this.instance.refs.button);
+    const button = TestUtils.findRenderedDOMComponentWithClass(
+      this.instance,
+      "button dropdown-toggle"
+    );
+    TestUtils.Simulate.click(button);
     // Find the selectable menu items
     var selectableElements = document.body.querySelectorAll(
       ".dropdown-menu .is-selectable"
@@ -85,15 +93,18 @@ describe("Dropdown", function() {
 
   it("correctly displays the selected item", function() {
     // Click on the dropdown button to open the menu
-    TestUtils.Simulate.click(this.instance.refs.button);
+    const button = TestUtils.findRenderedDOMComponentWithClass(
+      this.instance,
+      "button dropdown-toggle"
+    );
+    TestUtils.Simulate.click(button);
     // Find the selectable menu items
     var selectableElements = document.body.querySelectorAll(
       ".dropdown-menu .is-selectable"
     );
     // Click on the second menu item returned, which we know to be "Baz"
     TestUtils.Simulate.click(selectableElements[1]);
-    var buttonText = ReactDOM.findDOMNode(this.instance.refs.button)
-      .textContent;
+    var buttonText = ReactDOM.findDOMNode(button).textContent;
     expect(buttonText).toEqual("Baz");
   });
 
@@ -109,8 +120,12 @@ describe("Dropdown", function() {
         wrapperClassName="dropdown"
       />
     );
+    const button = TestUtils.findRenderedDOMComponentWithClass(
+      instance,
+      "button dropdown-toggle"
+    );
 
-    var buttonText = ReactDOM.findDOMNode(instance.refs.button).textContent;
+    var buttonText = ReactDOM.findDOMNode(button).textContent;
     expect(buttonText).toEqual("Quz");
   });
 
@@ -128,7 +143,12 @@ describe("Dropdown", function() {
       />
     );
 
-    var buttonText = ReactDOM.findDOMNode(instance.refs.button).textContent;
+    const button = TestUtils.findRenderedDOMComponentWithClass(
+      instance,
+      "button dropdown-toggle"
+    );
+
+    var buttonText = ReactDOM.findDOMNode(button).textContent;
     expect(buttonText).toEqual("Quz");
   });
 
@@ -144,8 +164,12 @@ describe("Dropdown", function() {
         wrapperClassName="dropdown"
       />
     );
+    const button = TestUtils.findRenderedDOMComponentWithClass(
+      instance,
+      "button dropdown-toggle"
+    );
 
-    var buttonText = ReactDOM.findDOMNode(instance.refs.button).textContent;
+    var buttonText = ReactDOM.findDOMNode(button).textContent;
     expect(buttonText).toEqual("");
   });
 
@@ -161,8 +185,12 @@ describe("Dropdown", function() {
         wrapperClassName="dropdown"
       />
     );
+    const button = TestUtils.findRenderedDOMComponentWithClass(
+      instance,
+      "button dropdown-toggle"
+    );
 
-    var buttonText = ReactDOM.findDOMNode(instance.refs.button).textContent;
+    var buttonText = ReactDOM.findDOMNode(button).textContent;
     expect(buttonText).toEqual("");
   });
 

--- a/src/Dropdown/__tests__/Dropdown-test.js
+++ b/src/Dropdown/__tests__/Dropdown-test.js
@@ -8,7 +8,13 @@ jest.dontMock("./fixtures/MockDropdownList");
 var React = require("react");
 /* eslint-enable no-unused-vars */
 var ReactDOM = require("react-dom");
-var TestUtils = require("react-addons-test-utils");
+
+var TestUtils;
+if (React.version.match(/15.[0-5]/)) {
+  TestUtils = require("react-addons-test-utils");
+} else {
+  TestUtils = require("react-dom/test-utils");
+}
 
 var MockDropdownList = require("./fixtures/MockDropdownList");
 var Dropdown = require("../Dropdown.js");

--- a/src/Form/FieldCheckbox.js
+++ b/src/Form/FieldCheckbox.js
@@ -1,5 +1,6 @@
 import classNames from "classnames/dedupe";
 import React from "react";
+import PropTypes from "prop-types";
 import ReactDOM from "react-dom";
 
 import FieldRadioButton from "./FieldRadioButton";
@@ -125,35 +126,32 @@ FieldCheckbox.defaultProps = {
 
 FieldCheckbox.propTypes = {
   // Optional number of columns to take up of the grid
-  columnWidth: React.PropTypes.number.isRequired,
+  columnWidth: PropTypes.number.isRequired,
   // Function to handle change event
   // (usually passed down from form definition)
-  handleEvent: React.PropTypes.func,
+  handleEvent: PropTypes.func,
   // Optional boolean, string, or react node.
   // If boolean: true - shows name as label; false - shows nothing.
   // If string: shows string as label.
   // If node: returns the node as the label.
-  showLabel: React.PropTypes.oneOfType([
-    React.PropTypes.node,
-    React.PropTypes.string,
-    React.PropTypes.bool
+  showLabel: PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.string,
+    PropTypes.bool
   ]),
   // Optional object of error messages, with key equal to field property name
-  validationError: React.PropTypes.object,
+  validationError: PropTypes.object,
 
   // Classes
-  checkboxButtonLabelClass: React.PropTypes.oneOfType([
-    React.PropTypes.array,
-    React.PropTypes.object,
-    React.PropTypes.string
+  checkboxButtonLabelClass: PropTypes.oneOfType([
+    PropTypes.array,
+    PropTypes.object,
+    PropTypes.string
   ]),
-  startValue: React.PropTypes.oneOfType([
-    React.PropTypes.array,
-    React.PropTypes.bool
-  ]),
-  labelClass: React.PropTypes.string,
-  indicatorClasses: React.PropTypes.string,
-  indeterminate: React.PropTypes.bool
+  startValue: PropTypes.oneOfType([PropTypes.array, PropTypes.bool]),
+  labelClass: PropTypes.string,
+  indicatorClasses: PropTypes.string,
+  indeterminate: PropTypes.bool
 };
 
 module.exports = FieldCheckbox;

--- a/src/Form/FieldInput.js
+++ b/src/Form/FieldInput.js
@@ -1,5 +1,6 @@
 import classNames from "classnames/dedupe";
 import React from "react";
+import PropTypes from "prop-types";
 import ReactDOM from "react-dom";
 
 import BindMixin from "../Mixin/BindMixin";
@@ -222,83 +223,83 @@ FieldInput.defaultProps = {
   writeType: "input"
 };
 
-const classPropType = React.PropTypes.oneOfType([
-  React.PropTypes.array,
-  React.PropTypes.object,
-  React.PropTypes.string
+const classPropType = PropTypes.oneOfType([
+  PropTypes.array,
+  PropTypes.object,
+  PropTypes.string
 ]);
 
 FieldInput.propTypes = {
   // Optional number of columns to take up of the grid
-  columnWidth: React.PropTypes.number.isRequired,
+  columnWidth: PropTypes.number.isRequired,
   // Optional. Which field property is currently being edited
   // (usually passed down from form definition)
-  editing: React.PropTypes.string,
+  editing: PropTypes.string,
   // Optional. Specify if the field should be focused
   // Useful in combination with preset values, will set cursor to end of input
   // (usually passed down from form definition)
-  focused: React.PropTypes.bool,
+  focused: PropTypes.bool,
   // Function to handle when form is submitted
   // (usually passed down from form definition)
-  handleSubmit: React.PropTypes.func,
+  handleSubmit: PropTypes.func,
   // Function to handle events like 'change', 'blur', 'focus', etc on the field
   // (usually passed down from form definition)
-  handleEvent: React.PropTypes.func,
+  handleEvent: PropTypes.func,
   // Optional label to add
-  label: React.PropTypes.string,
+  label: PropTypes.string,
   // Optional help block
-  helpBlock: React.PropTypes.node,
+  helpBlock: PropTypes.node,
   // Name of the field property
   // (usually passed down from form definition)
-  name: React.PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
   // Custom render function, receives the input element as its only argument
-  renderer: React.PropTypes.func,
+  renderer: PropTypes.func,
   // Optional boolean, string, or react node.
   // If boolean: true - shows name as label; false - shows nothing.
   // If string: shows string as label.
   // If node: returns the node as the label.
-  showLabel: React.PropTypes.oneOfType([
-    React.PropTypes.node,
-    React.PropTypes.string,
-    React.PropTypes.bool
+  showLabel: PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.string,
+    PropTypes.bool
   ]),
   // initial value of field
-  startValue: React.PropTypes.oneOfType([
-    React.PropTypes.bool,
-    React.PropTypes.number,
-    React.PropTypes.string
+  startValue: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.number,
+    PropTypes.string
   ]),
   // Optional object of error messages, with key equal to field property name
-  validationError: React.PropTypes.object,
+  validationError: PropTypes.object,
   // Optional value of the field
-  value: React.PropTypes.oneOfType([
-    React.PropTypes.bool,
-    React.PropTypes.number,
-    React.PropTypes.string
+  value: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.number,
+    PropTypes.string
   ]),
   // Optional field to set input to 'edit' or 'input' mode
-  writeType: React.PropTypes.string,
+  writeType: PropTypes.string,
 
   // Classes
   formElementClass: classPropType,
   formGroupClass: classPropType,
   // Class to be toggled, can be overridden by formGroupClass
-  formGroupErrorClass: React.PropTypes.string,
+  formGroupErrorClass: PropTypes.string,
   helpBlockClass: classPropType,
   inlineIconClass: classPropType,
   inlineTextClass: classPropType,
   labelClass: classPropType,
   sharedClass: classPropType,
-  fieldType: React.PropTypes.string,
-  currentValue: React.PropTypes.object,
-  maxColumnWidth: React.PropTypes.number,
-  formRowClass: React.PropTypes.string,
-  inputClass: React.PropTypes.string,
-  readClass: React.PropTypes.string,
-  validation: React.PropTypes.func,
-  validationErrorText: React.PropTypes.string,
-  showError: React.PropTypes.string,
-  errorText: React.PropTypes.string
+  fieldType: PropTypes.string,
+  currentValue: PropTypes.object,
+  maxColumnWidth: PropTypes.number,
+  formRowClass: PropTypes.string,
+  inputClass: PropTypes.string,
+  readClass: PropTypes.string,
+  validation: PropTypes.func,
+  validationErrorText: PropTypes.string,
+  showError: PropTypes.string,
+  errorText: PropTypes.string
 };
 
 module.exports = FieldInput;

--- a/src/Form/FieldRadioButton.js
+++ b/src/Form/FieldRadioButton.js
@@ -1,5 +1,6 @@
 import classNames from "classnames/dedupe";
 import React from "react";
+import PropTypes from "prop-types";
 
 import BindMixin from "../Mixin/BindMixin";
 import Util from "../Util/Util";
@@ -185,41 +186,38 @@ FieldRadioButton.defaultProps = {
   handleEvent() {}
 };
 
-const classPropType = React.PropTypes.oneOfType([
-  React.PropTypes.array,
-  React.PropTypes.object,
-  React.PropTypes.string
+const classPropType = PropTypes.oneOfType([
+  PropTypes.array,
+  PropTypes.object,
+  PropTypes.string
 ]);
 
 FieldRadioButton.propTypes = {
   // Optional number of columns to take up of the grid
-  columnWidth: React.PropTypes.number.isRequired,
+  columnWidth: PropTypes.number.isRequired,
   // Function to handle change event
   // (usually passed down from form definition)
-  handleEvent: React.PropTypes.func,
+  handleEvent: PropTypes.func,
   // Optional boolean, string, or react node.
   // If boolean: true - shows name as label; false - shows nothing.
   // If string: shows string as label.
   // If node: returns the node as the label.
-  showLabel: React.PropTypes.oneOfType([
-    React.PropTypes.node,
-    React.PropTypes.string,
-    React.PropTypes.bool
+  showLabel: PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.string,
+    PropTypes.bool
   ]),
   // Attributes to pass to radio button(s)
   // (usually passed down from form definition)
-  startValue: React.PropTypes.oneOfType([
-    React.PropTypes.array,
-    React.PropTypes.bool
-  ]),
+  startValue: PropTypes.oneOfType([PropTypes.array, PropTypes.bool]),
   // Optional object of error messages, with key equal to field property name
-  validationError: React.PropTypes.object,
+  validationError: PropTypes.object,
 
   // Classes
   formElementClass: classPropType,
   formGroupClass: classPropType,
   // Class to be toggled, can be overridden by formGroupClass
-  formGroupErrorClass: React.PropTypes.string,
+  formGroupErrorClass: PropTypes.string,
   helpBlockClass: classPropType,
   itemWrapperClass: classPropType,
   labelClass: classPropType,

--- a/src/Form/FieldSelect.js
+++ b/src/Form/FieldSelect.js
@@ -1,5 +1,6 @@
 import classNames from "classnames/dedupe";
 import React from "react";
+import PropTypes from "prop-types";
 
 import Dropdown from "../Dropdown/Dropdown";
 import Util from "../Util/Util";
@@ -171,59 +172,59 @@ FieldSelect.defaultProps = {
   handleEvent() {}
 };
 
-const classPropType = React.PropTypes.oneOfType([
-  React.PropTypes.array,
-  React.PropTypes.object,
-  React.PropTypes.string
+const classPropType = PropTypes.oneOfType([
+  PropTypes.array,
+  PropTypes.object,
+  PropTypes.string
 ]);
 
 FieldSelect.propTypes = {
   // Optional number of columns to take up of the grid
-  columnWidth: React.PropTypes.number.isRequired,
+  columnWidth: PropTypes.number.isRequired,
 
   // Name of the field property
   // (usually passed down from form definition)
-  name: React.PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
   // Optional boolean, string, or react node.
   // If boolean: true - shows name as label; false - shows nothing.
   // If string: shows string as label.
   // If node: returns the node as the label.
-  showLabel: React.PropTypes.oneOfType([
-    React.PropTypes.node,
-    React.PropTypes.string,
-    React.PropTypes.bool
+  showLabel: PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.string,
+    PropTypes.bool
   ]),
 
   // Function to handle events like 'change', 'blur', 'focus', etc on the field
   // (usually passed down from form definition)
-  handleEvent: React.PropTypes.func,
+  handleEvent: PropTypes.func,
 
   // These are the options for the DropDown Component
-  options: React.PropTypes.arrayOf(
-    React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.shape({
-        html: React.PropTypes.node,
-        id: React.PropTypes.string
+  options: PropTypes.arrayOf(
+    PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.shape({
+        html: PropTypes.node,
+        id: PropTypes.string
       })
     ])
   ).isRequired,
-  startValue: React.PropTypes.oneOfType([
-    React.PropTypes.string,
-    React.PropTypes.shape({
-      html: React.PropTypes.node,
-      id: React.PropTypes.string
+  startValue: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.shape({
+      html: PropTypes.node,
+      id: PropTypes.string
     })
   ]),
-  persisitentID: React.PropTypes.string,
+  persisitentID: PropTypes.string,
 
   // Optional object of error messages, with key equal to field property name
-  validationError: React.PropTypes.object,
+  validationError: PropTypes.object,
 
   // Classes
   formGroupClass: classPropType,
   // Class to be toggled, can be overridden by formGroupClass
-  formGroupErrorClass: React.PropTypes.string,
+  formGroupErrorClass: PropTypes.string,
   helpBlockClass: classPropType,
   formElementClass: classPropType,
 

--- a/src/Form/FieldSubmit.js
+++ b/src/Form/FieldSubmit.js
@@ -1,5 +1,6 @@
 import classNames from "classnames/dedupe";
 import React from "react";
+import PropTypes from "prop-types";
 
 import Util from "../Util/Util";
 
@@ -40,22 +41,22 @@ FieldSubmit.defaultProps = {
   handleSubmit() {}
 };
 
-const classPropType = React.PropTypes.oneOfType([
-  React.PropTypes.array,
-  React.PropTypes.object,
-  React.PropTypes.string
+const classPropType = PropTypes.oneOfType([
+  PropTypes.array,
+  PropTypes.object,
+  PropTypes.string
 ]);
 
 FieldSubmit.propTypes = {
   // Optional number of columns to take up of the grid
-  columnWidth: React.PropTypes.number.isRequired,
+  columnWidth: PropTypes.number.isRequired,
 
   // Function to handle when form is submitted
   // (usually passed down from form definition)
-  handleSubmit: React.PropTypes.func,
+  handleSubmit: PropTypes.func,
 
   // Text inside button
-  buttonText: React.PropTypes.string,
+  buttonText: PropTypes.string,
 
   // Classes
   buttonClass: classPropType,

--- a/src/Form/FieldTextarea.js
+++ b/src/Form/FieldTextarea.js
@@ -1,6 +1,7 @@
 import classNames from "classnames/dedupe";
 /* eslint-disable no-unused-vars */
 import React from "react";
+import PropTypes from "prop-types";
 /* eslint-enable no-unused-vars */
 import throttle from "lodash.throttle";
 
@@ -147,9 +148,9 @@ FieldTextarea.defaultProps = {
 };
 
 FieldTextarea.propTypes = {
-  maxHeight: React.PropTypes.number,
-  minHeight: React.PropTypes.number,
-  scrollHeightOffset: React.PropTypes.number
+  maxHeight: PropTypes.number,
+  minHeight: PropTypes.number,
+  scrollHeightOffset: PropTypes.number
 };
 
 module.exports = FieldTextarea;

--- a/src/Form/Form.js
+++ b/src/Form/Form.js
@@ -1,5 +1,6 @@
 import classNames from "classnames/dedupe";
-import React, { PropTypes } from "react";
+import React from "react";
+import PropTypes from "prop-types";
 
 import BindMixin from "../Mixin/BindMixin";
 import FormControl from "./FormControl";
@@ -419,10 +420,10 @@ class Form extends Util.mixin(BindMixin) {
   }
 }
 
-const classPropType = React.PropTypes.oneOfType([
-  React.PropTypes.array,
-  React.PropTypes.object,
-  React.PropTypes.string
+const classPropType = PropTypes.oneOfType([
+  PropTypes.array,
+  PropTypes.object,
+  PropTypes.string
 ]);
 
 Form.defaultProps = {
@@ -456,7 +457,7 @@ Form.propTypes = {
   // 1. Array of field definitions will be created on same row
   // 2. Field definition (object) will create a single field in that row
   definition: PropTypes.arrayOf(
-    React.PropTypes.oneOfType([React.PropTypes.object, React.PropTypes.array])
+    PropTypes.oneOfType([PropTypes.object, PropTypes.array])
   ),
 
   // Optional number of columns in the grid

--- a/src/Form/FormControl.js
+++ b/src/Form/FormControl.js
@@ -1,5 +1,6 @@
 import classNames from "classnames/dedupe";
 import React from "react";
+import PropTypes from "prop-types";
 
 import FieldTypes from "./FieldTypes";
 import Util from "../Util/Util";
@@ -83,18 +84,15 @@ class FormControl extends React.Component {
 
 FormControl.propTypes = {
   // Optional number of columns in the grid
-  maxColumnWidth: React.PropTypes.number,
+  maxColumnWidth: PropTypes.number,
 
   // Object with key as field propterty name, and value as current value
-  currentValue: React.PropTypes.object,
+  currentValue: PropTypes.object,
 
   // Form definition to build the form from. Can be either:
   // 1. Array of field definitions will be created on same row
   // 2. Field definition (object) will create a single field in that row
-  definition: React.PropTypes.oneOfType([
-    React.PropTypes.object,
-    React.PropTypes.array
-  ])
+  definition: PropTypes.oneOfType([PropTypes.object, PropTypes.array])
 };
 
 module.exports = FormControl;

--- a/src/Form/__tests__/FieldCheckbox-test.js
+++ b/src/Form/__tests__/FieldCheckbox-test.js
@@ -5,7 +5,13 @@ jest.dontMock("../FieldRadioButton");
 var React = require("react");
 /* eslint-enable no-unused-vars */
 var ReactDOM = require("react-dom");
-var TestUtils = require("react-addons-test-utils");
+
+var TestUtils;
+if (React.version.match(/15.[0-5]/)) {
+  TestUtils = require("react-addons-test-utils");
+} else {
+  TestUtils = require("react-dom/test-utils");
+}
 
 var FieldCheckbox = require("../FieldCheckbox");
 

--- a/src/Form/__tests__/FieldInput-test.js
+++ b/src/Form/__tests__/FieldInput-test.js
@@ -6,7 +6,13 @@ jest.dontMock("../../Util/KeyboardUtil");
 var React = require("react");
 var ReactDOM = require("react-dom");
 /* eslint-enable no-unused-vars */
-var TestUtils = require("react-addons-test-utils");
+
+var TestUtils;
+if (React.version.match(/15.[0-5]/)) {
+  TestUtils = require("react-addons-test-utils");
+} else {
+  TestUtils = require("react-dom/test-utils");
+}
 
 var FieldInput = require("../FieldInput");
 

--- a/src/Form/__tests__/FieldRadioButton-test.js
+++ b/src/Form/__tests__/FieldRadioButton-test.js
@@ -3,7 +3,13 @@ jest.dontMock("../FieldRadioButton");
 /* eslint-disable no-unused-vars */
 var React = require("react");
 /* eslint-enable no-unused-vars */
-var TestUtils = require("react-addons-test-utils");
+
+var TestUtils;
+if (React.version.match(/15.[0-5]/)) {
+  TestUtils = require("react-addons-test-utils");
+} else {
+  TestUtils = require("react-dom/test-utils");
+}
 
 var FieldRadioButton = require("../FieldRadioButton");
 

--- a/src/Form/__tests__/FieldSelect-test.js
+++ b/src/Form/__tests__/FieldSelect-test.js
@@ -5,7 +5,13 @@ jest.dontMock("../../Util/KeyboardUtil");
 /* eslint-disable no-unused-vars */
 var React = require("react");
 /* eslint-enable no-unused-vars */
-var TestUtils = require("react-addons-test-utils");
+
+var TestUtils;
+if (React.version.match(/15.[0-5]/)) {
+  TestUtils = require("react-addons-test-utils");
+} else {
+  TestUtils = require("react-dom/test-utils");
+}
 
 var FieldSelect = require("../FieldSelect");
 

--- a/src/Form/__tests__/Form-test.js
+++ b/src/Form/__tests__/Form-test.js
@@ -10,7 +10,13 @@ jest.dontMock("../../Util/Util");
 /* eslint-disable no-unused-vars */
 var React = require("react");
 /* eslint-enable no-unused-vars */
-var TestUtils = require("react-addons-test-utils");
+
+var TestUtils;
+if (React.version.match(/15.[0-5]/)) {
+  TestUtils = require("react-addons-test-utils");
+} else {
+  TestUtils = require("react-dom/test-utils");
+}
 
 var Form = require("../Form");
 var FormControl = require("../FormControl");

--- a/src/Form/__tests__/FormControl-test.js
+++ b/src/Form/__tests__/FormControl-test.js
@@ -7,7 +7,13 @@ jest.dontMock("../../Util/Util");
 /* eslint-disable no-unused-vars */
 var React = require("react");
 /* eslint-enable no-unused-vars */
-var TestUtils = require("react-addons-test-utils");
+
+var TestUtils;
+if (React.version.match(/15.[0-5]/)) {
+  TestUtils = require("react-addons-test-utils");
+} else {
+  TestUtils = require("react-dom/test-utils");
+}
 
 var FormControl = require("../FormControl");
 

--- a/src/List/List.js
+++ b/src/List/List.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import React from "react";
+import PropTypes from "prop-types";
 import { CSSTransitionGroup } from "react-transition-group";
 
 import ListItem from "./ListItem";
@@ -107,8 +108,8 @@ List.propTypes = {
   transition: PropTypes.bool,
   transitionName: PropTypes.string,
   // Transition lengths
-  transitionEnterTimeout: React.PropTypes.number,
-  transitionLeaveTimeout: React.PropTypes.number
+  transitionEnterTimeout: PropTypes.number,
+  transitionLeaveTimeout: PropTypes.number
 };
 
 module.exports = List;

--- a/src/List/List.js
+++ b/src/List/List.js
@@ -1,5 +1,5 @@
 import React, { PropTypes } from "react";
-import ReactCSSTransitionGroup from "react-addons-css-transition-group";
+import { CSSTransitionGroup } from "react-transition-group";
 
 import ListItem from "./ListItem";
 import Util from "../Util/Util";
@@ -53,7 +53,7 @@ class List extends React.Component {
 
     if (props.transition) {
       return (
-        <ReactCSSTransitionGroup
+        <CSSTransitionGroup
           {...htmlAttributes}
           className={props.className}
           component={Tag}
@@ -62,7 +62,7 @@ class List extends React.Component {
           transitionLeaveTimeout={props.transitionLeaveTimeout}
         >
           {this.getListItems(props.content)}
-        </ReactCSSTransitionGroup>
+        </CSSTransitionGroup>
       );
     }
 

--- a/src/List/ListItem.js
+++ b/src/List/ListItem.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import React from "react";
+import PropTypes from "prop-types";
 import { CSSTransitionGroup } from "react-transition-group";
 
 import Util from "../Util/Util";

--- a/src/List/ListItem.js
+++ b/src/List/ListItem.js
@@ -1,5 +1,5 @@
 import React, { PropTypes } from "react";
-import ReactCSSTransitionGroup from "react-addons-css-transition-group";
+import { CSSTransitionGroup } from "react-transition-group";
 
 import Util from "../Util/Util";
 
@@ -13,13 +13,13 @@ class ListItem extends React.Component {
 
     if (props.transition) {
       return (
-        <ReactCSSTransitionGroup
+        <CSSTransitionGroup
           {...htmlAttributes}
           className={props.className}
           component={props.tag}
         >
           {props.children}
-        </ReactCSSTransitionGroup>
+        </CSSTransitionGroup>
       );
     }
 

--- a/src/List/__tests__/List-test.js
+++ b/src/List/__tests__/List-test.js
@@ -1,7 +1,13 @@
 /* eslint-disable no-unused-vars */
 var React = require("react");
 /* eslint-enable no-unused-vars */
-var TestUtils = require("react-addons-test-utils");
+
+var TestUtils;
+if (React.version.match(/15.[0-5]/)) {
+  TestUtils = require("react-addons-test-utils");
+} else {
+  TestUtils = require("react-dom/test-utils");
+}
 
 jest.dontMock("../List.js");
 jest.dontMock("../ListItem.js");

--- a/src/Modal/ModalContents.js
+++ b/src/Modal/ModalContents.js
@@ -9,7 +9,7 @@ import React, { PropTypes } from "react";
  * interaction changes open to true -> render modal content without scrollbars
  * get height of content -> rerender modal content and cap the height
  */
-import ReactCSSTransitionGroup from "react-addons-css-transition-group";
+import { CSSTransitionGroup } from "react-transition-group";
 
 import BindMixin from "../Mixin/BindMixin";
 import DOMUtil from "../Util/DOMUtil";
@@ -140,27 +140,27 @@ class ModalContents extends Util.mixin(BindMixin) {
     }
 
     const {
-      footer,
-      header,
-      modal,
-      innerContent,
-      innerContentContainer
-    } = this.refs;
+      footerRef,
+      headerRef,
+      modalRef,
+      innerContentRef,
+      innerContentContainerRef
+    } = this;
 
     let headerHeight = 0;
     let footerHeight = 0;
 
-    if (header != null) {
-      headerHeight = Math.ceil(header.getBoundingClientRect().height);
+    if (headerRef != null) {
+      headerHeight = Math.ceil(headerRef.getBoundingClientRect().height);
     }
 
-    if (footer != null) {
-      footerHeight = Math.ceil(footer.getBoundingClientRect().height);
+    if (footerRef != null) {
+      footerHeight = Math.ceil(footerRef.getBoundingClientRect().height);
     }
 
-    const modalHeight = Math.ceil(modal.getBoundingClientRect().height);
+    const modalHeight = Math.ceil(modalRef.getBoundingClientRect().height);
     const innerContentHeight = Math.ceil(
-      innerContent.getBoundingClientRect().height
+      innerContentRef.getBoundingClientRect().height
     );
     const maxModalHeight =
       this.lastViewportHeight - MODAL_VERTICAL_INSET_DISTANCE;
@@ -202,8 +202,8 @@ class ModalContents extends Util.mixin(BindMixin) {
       }
     }
 
-    innerContentContainer.style.height = nextInnerContentContainerHeight;
-    modal.style.height = nextModalHeight;
+    innerContentContainerRef.style.height = nextInnerContentContainerHeight;
+    modalRef.style.height = nextModalHeight;
 
     this.triggerGeminiUpdate();
   }
@@ -230,7 +230,10 @@ class ModalContents extends Util.mixin(BindMixin) {
     }
 
     return (
-      <div className={props.headerClass} ref="header">
+      <div
+        className={props.headerClass}
+        ref={element => (this.headerRef = element)}
+      >
         {props.header}
         {props.subHeader}
       </div>
@@ -245,7 +248,10 @@ class ModalContents extends Util.mixin(BindMixin) {
     }
 
     return (
-      <div className={props.footerClass} ref="footer">
+      <div
+        className={props.footerClass}
+        ref={element => (this.footerRef = element)}
+      >
         {props.footer}
       </div>
     );
@@ -255,7 +261,10 @@ class ModalContents extends Util.mixin(BindMixin) {
     const { props, state } = this;
 
     const modalContent = (
-      <div className={props.scrollContainerClass} ref="innerContent">
+      <div
+        className={props.scrollContainerClass}
+        ref={element => (this.innerContentRef = element)}
+      >
         {props.children}
       </div>
     );
@@ -281,7 +290,7 @@ class ModalContents extends Util.mixin(BindMixin) {
       <GeminiScrollbar
         autoshow={false}
         className={geminiClasses}
-        ref="gemini"
+        ref={element => (this.geminiRef = element)}
         style={geminiContainerStyle}
       >
         {modalContent}
@@ -302,13 +311,16 @@ class ModalContents extends Util.mixin(BindMixin) {
     }
 
     return (
-      <div ref="modal" className={props.modalClass}>
+      <div
+        ref={element => (this.modalRef = element)}
+        className={props.modalClass}
+      >
         {this.getCloseButton()}
         {this.getHeader()}
         <div
           className={props.bodyClass}
           style={modalBodyStyle}
-          ref="innerContentContainer"
+          ref={element => (this.innerContentContainerRef = element)}
         >
           {this.getModalContent()}
         </div>
@@ -330,10 +342,8 @@ class ModalContents extends Util.mixin(BindMixin) {
   }
 
   triggerGeminiUpdate() {
-    const { gemini } = this.refs;
-
-    if (gemini != null && gemini.scrollbar != null) {
-      gemini.scrollbar.update();
+    if (this.geminiRef != null && this.geminiRef.scrollbar != null) {
+      this.geminiRef.scrollbar.update();
     }
   }
 
@@ -351,7 +361,7 @@ class ModalContents extends Util.mixin(BindMixin) {
     }
 
     return (
-      <ReactCSSTransitionGroup
+      <CSSTransitionGroup
         transitionAppear={props.transitionAppear}
         transitionEnter={props.transitionEnter}
         transitionLeave={props.transitionLeave}
@@ -362,7 +372,7 @@ class ModalContents extends Util.mixin(BindMixin) {
         component="div"
       >
         {modalContent}
-      </ReactCSSTransitionGroup>
+      </CSSTransitionGroup>
     );
   }
 }

--- a/src/Modal/ModalContents.js
+++ b/src/Modal/ModalContents.js
@@ -1,8 +1,9 @@
 import classNames from "classnames/dedupe";
 import GeminiScrollbar from "react-gemini-scrollbar";
 /* eslint-disable no-unused-vars */
-import React, { PropTypes } from "react";
+import React from "react";
 /* eslint-enable no-unused-vars */
+import PropTypes from "prop-types";
 /**
  * Lifecycle of a Modal:
  * initial page load -> empty ReactCSSTransitionGroup
@@ -450,9 +451,9 @@ ModalContents.propTypes = {
   closeButtonClass: PropTypes.string,
   footerClass: PropTypes.string,
   geminiClass: PropTypes.oneOfType([
-    React.PropTypes.array,
-    React.PropTypes.object,
-    React.PropTypes.string
+    PropTypes.array,
+    PropTypes.object,
+    PropTypes.string
   ]),
   headerClass: PropTypes.string,
   modalClass: PropTypes.string,

--- a/src/Modal/__tests__/ModalContents-test.js
+++ b/src/Modal/__tests__/ModalContents-test.js
@@ -1,8 +1,14 @@
+import ReactDOM from "react-dom";
 /* eslint-disable no-unused-vars */
 var React = require("react");
 /* eslint-enable no-unused-vars */
-import ReactDOM from "react-dom";
-var TestUtils = require("react-addons-test-utils");
+
+var TestUtils;
+if (React.version.match(/15.[0-5]/)) {
+  TestUtils = require("react-addons-test-utils");
+} else {
+  TestUtils = require("react-dom/test-utils");
+}
 
 jest.dontMock("../../Util/DOMUtil");
 jest.dontMock("../ModalContents");

--- a/src/Portal/Portal.js
+++ b/src/Portal/Portal.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import React from "react";
+import PropTypes from "prop-types";
 import ReactDOM from "react-dom";
 
 class Portal extends React.Component {

--- a/src/Table/Table.js
+++ b/src/Table/Table.js
@@ -1,5 +1,6 @@
 import classNames from "classnames";
-import React, { PropTypes } from "react";
+import React from "react";
+import PropTypes from "prop-types";
 import ReactDOM from "react-dom";
 
 import DOMUtil from "../Util/DOMUtil";

--- a/src/Table/__tests__/Table-test.js
+++ b/src/Table/__tests__/Table-test.js
@@ -6,7 +6,14 @@ jest.dontMock("./fixtures/MockTable");
 var React = require("react");
 /* eslint-enable no-unused-vars */
 var ReactDOM = require("react-dom");
-var TestUtils = require("react-addons-test-utils");
+
+var TestUtils;
+if (React.version.match(/15.[0-5]/)) {
+  TestUtils = require("react-addons-test-utils");
+} else {
+  TestUtils = require("react-dom/test-utils");
+}
+
 var Table = require("../Table");
 var DOMUtil = require("../../Util/DOMUtil");
 

--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -1,5 +1,6 @@
 import classnames from "classnames";
 import React from "react";
+import PropTypes from "prop-types";
 
 import BindMixin from "../Mixin/BindMixin";
 import DOMUtil from "../Util/DOMUtil";
@@ -302,34 +303,31 @@ Tooltip.propTypes = {
   // to the logical respective edges of the tooltip. When tooltip is positioned
   // on the right, start refers to the top of the tooltip. When tooltip is
   // positioned on the bottom, start refers to the left edge of the tooltip.
-  anchor: React.PropTypes.oneOf(["start", "center", "end"]),
+  anchor: PropTypes.oneOf(["start", "center", "end"]),
   // The children will be used as the trigger.
-  children: React.PropTypes.node.isRequired,
-  className: React.PropTypes.string,
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string,
   // The tooltip's content.
-  content: React.PropTypes.node.isRequired,
+  content: PropTypes.node.isRequired,
   // The type of node rendered.
-  elementTag: React.PropTypes.string,
+  elementTag: PropTypes.string,
   // Allows user interaction on tooltips. When false, the tooltip is dismissed
   // when the mouse leaves the trigger. When true, the mouse is allowed to enter
   // the tooltip. Default is false.
-  interactive: React.PropTypes.bool,
-  maxWidth: React.PropTypes.oneOfType([
-    React.PropTypes.number,
-    React.PropTypes.string
-  ]),
+  interactive: PropTypes.bool,
+  maxWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   // Position the tooltip on an edge of the tooltip trigger. Default is top.
-  position: React.PropTypes.oneOf(["top", "bottom", "right", "left"]),
+  position: PropTypes.oneOf(["top", "bottom", "right", "left"]),
   // Keeps a tooltip open after it's triggered. Defaults to false.
-  stayOpen: React.PropTypes.bool,
+  stayOpen: PropTypes.bool,
   // Prevents a tooltip from being displayed. Defaults to false.
-  suppress: React.PropTypes.bool,
+  suppress: PropTypes.bool,
   // Explicitly set the width of the tooltip. Default is auto.
-  width: React.PropTypes.number,
-  wrapperClassName: React.PropTypes.string,
+  width: PropTypes.number,
+  wrapperClassName: PropTypes.string,
   // Allow the text content to wrap. Default is false.
-  wrapText: React.PropTypes.bool,
-  contentClassName: React.PropTypes.string
+  wrapText: PropTypes.bool,
+  contentClassName: PropTypes.string
 };
 
 module.exports = Tooltip;

--- a/src/Tooltip/__tests__/Tooltip-test.js
+++ b/src/Tooltip/__tests__/Tooltip-test.js
@@ -4,7 +4,14 @@ jest.dontMock("../../Util/Util");
 /* eslint-disable no-unused-vars */
 var React = require("react");
 /* eslint-enable no-unused-vars */
-var TestUtils = require("react-addons-test-utils");
+
+var TestUtils;
+if (React.version.match(/15.[0-5]/)) {
+  TestUtils = require("react-addons-test-utils");
+} else {
+  TestUtils = require("react-dom/test-utils");
+}
+
 var Tooltip = require("../Tooltip");
 
 describe("Tooltip", function() {

--- a/src/VirtualList/VirtualList.js
+++ b/src/VirtualList/VirtualList.js
@@ -4,6 +4,7 @@
  */
 
 import React from "react";
+import PropTypes from "prop-types";
 import ReactDOM from "react-dom";
 import throttle from "lodash.throttle";
 
@@ -255,32 +256,32 @@ VirtualList.defaultProps = {
 
 VirtualList.propTypes = {
   // Array of items to render
-  items: React.PropTypes.array.isRequired,
+  items: PropTypes.array.isRequired,
 
   // The fixed height of a single item. Needs to be the same for all items
   // We suggest that you add a CSS rule to set the row height to the same value
-  itemHeight: React.PropTypes.number.isRequired,
+  itemHeight: PropTypes.number.isRequired,
 
   // This function should return the item view, the data model and the index
   // is passed to the function.
   // If you want to tweak performance, we suggest you memoize the results
-  renderItem: React.PropTypes.func.isRequired,
+  renderItem: PropTypes.func.isRequired,
 
   // This function should return an item buffer view, the data model and the
   // index is passed to the function.
-  renderBufferItem: React.PropTypes.func.isRequired,
+  renderBufferItem: PropTypes.func.isRequired,
 
   // Optional item that the items should be rendered within. Defaults to window
-  container: React.PropTypes.object,
+  container: PropTypes.object,
 
   // Optional Specify which tag the container should render
-  tagName: React.PropTypes.string,
+  tagName: PropTypes.string,
 
   // Optional scroll delay to use in throttle function
-  scrollDelay: React.PropTypes.number,
+  scrollDelay: PropTypes.number,
 
   // Optional number of items to use as buffer, before and after viewport
-  itemBuffer: React.PropTypes.number
+  itemBuffer: PropTypes.number
 };
 
 module.exports = VirtualList;


### PR DESCRIPTION
This is a long overdue work. Please go commit by commit when review. Chores have been done to enable react@16 upgrade.

- dropped react@0.14
- react-addons-css-transition-group -> react-transition-group
- react-addons-test-utils -> react-dom/test-utils
- React.PropTypes -> prop-types package
- Spread react versions to support ^15.0.0

