### PR TITLE
Dropdown: Add disabled state in dropdown

### DIFF
--- a/docs/src/Dropdown/index.js
+++ b/docs/src/Dropdown/index.js
@@ -204,6 +204,53 @@ class SimpleDropdownExample extends React.Component {
         </ComponentExampleWrapper>
         <ComponentExampleWrapper>
           <ComponentExample>
+            <div className="row">
+              <div className="column-6">
+                <p>Here is a disabled dropdown...</p>
+                <Dropdown
+                  buttonClassName="button dropdown-toggle"
+                  dropdownMenuClassName="dropdown-menu"
+                  dropdownMenuListClassName="dropdown-menu-list"
+                  items={dropdownItems}
+                  initialID="bar"
+                  scrollContainer={this.props.scrollContainer}
+                  transition={true}
+                  wrapperClassName="dropdown"
+                  disabled
+                />
+              </div>
+            </div>
+          </ComponentExample>
+          <CodeBlock>
+            {`import {Dropdown} from 'reactjs-components';
+import React from 'react';
+
+class SimpleDropdownExample extends React.Component {
+  render() {
+    let dropdownItems = [
+      {html: 'Foo', id: 'foo'},
+      {html: 'Bar', id: 'bar'},
+      {html: 'Baz', id: 'baz'},
+      {html: 'A tiny whale', id: 'whale'}
+    ];
+
+    return (
+      <Dropdown buttonClassName="button dropdown-toggle"
+        dropdownMenuClassName="dropdown-menu"
+        dropdownMenuListClassName="dropdown-menu-list"
+        items={dropdownItems}
+        initialID="foo"
+        transition={true}
+        wrapperClassName="dropdown"
+        disabled
+        />
+    );
+  }
+}`}
+          </CodeBlock>
+        </ComponentExampleWrapper>
+        <ComponentExampleWrapper>
+          <ComponentExample>
             <h4 className="flush-top">Callbacks</h4>
             <p>
               Use the <code>onItemSelection</code> attribute to add

--- a/src/Dropdown/Dropdown.js
+++ b/src/Dropdown/Dropdown.js
@@ -406,6 +406,7 @@ class Dropdown extends Util.mixin(BindMixin) {
           onClick={this.handleMenuToggle}
           ref="button"
           type="button"
+          disabled={props.disabled}
         >
           {this.getSelectedHtml(this.getSelectedID(), items)}
         </button>
@@ -427,7 +428,8 @@ Dropdown.defaultProps = {
   transitionEnterTimeout: 250,
   transitionLeaveTimeout: 250,
   onItemSelection: () => {},
-  useGemini: true
+  useGemini: true,
+  disabled: false
 };
 
 Dropdown.propTypes = {
@@ -493,6 +495,8 @@ Dropdown.propTypes = {
   transitionLeaveTimeout: React.PropTypes.number,
   // Option to use Gemini scrollbar. Defaults to true.
   useGemini: React.PropTypes.bool,
+  // Disable dropdown
+  disabled: React.PropTypes.bool,
 
   // Classes:
   // Classname for the element that ther user interacts with to open menu.

--- a/src/Dropdown/__tests__/Dropdown-test.js
+++ b/src/Dropdown/__tests__/Dropdown-test.js
@@ -91,6 +91,24 @@ describe("Dropdown", function() {
     expect(buttonText).toEqual("Baz");
   });
 
+  it("disables button when disabled state is enabled", function() {
+    var instance = TestUtils.renderIntoDocument(
+      <Dropdown
+        buttonClassName="button dropdown-toggle"
+        dropdownMenuClassName="dropdown-menu"
+        dropdownMenuListClassName="dropdown-menu-list"
+        items={MockDropdownList}
+        persistentID="quz"
+        transition={false}
+        wrapperClassName="dropdown"
+        disabled
+      />
+    );
+
+    var disabledState = ReactDOM.findDOMNode(instance.refs.button).disabled;
+    expect(disabledState).toEqual(true);
+  });
+
   it("correctly displays the selected item with persistentID", function() {
     var instance = TestUtils.renderIntoDocument(
       <Dropdown


### PR DESCRIPTION
This adds a disabled state in the dropdown. It is like the "select" element where you can just add a disabled attribute and it disables the dropdown.

Add disabled state in Dropdown.
Include doc page for disabled instance.
Include test for disabled Dropdown instance.

![image](https://user-images.githubusercontent.com/180432/31146875-d5fea42c-a83c-11e7-91d6-7b5f0bfd852f.png)
