### PR TITLE
feat(select): create a new select component wrapping the existing dropdown

### DIFF
--- a/docs/src/Select/index.js
+++ b/docs/src/Select/index.js
@@ -1,0 +1,96 @@
+import React from "react";
+
+import CodeBlock from "../components/CodeBlock";
+import ComponentExample from "../components/ComponentExample";
+import ComponentExampleWrapper from "../components/ComponentExampleWrapper";
+import ComponentWrapper from "../components/ComponentWrapper";
+import Select from "../../../src/Select/Select.js";
+import SelectOption from "../../../src/Select/SelectOption.js";
+import PropertiesAPIBlock from "../components/PropertiesAPIBlock";
+
+class SelectExample extends React.Component {
+  render() {
+    return (
+      <ComponentWrapper
+        title="Select"
+        srcURI="https://github.com/mesosphere/reactjs-components/blob/master/src/Select/Select.js"
+      >
+        <p className="lead flush-bottom">
+          To allow a enclosing
+          {" "}
+          <code>form</code>
+          {" "}
+          recognize the change of a
+          {" "}
+          <code>Dropdown</code>
+          , it is necceccary that there is an
+          {" "}
+          <code>input</code>
+          {" "}
+          element which emits a proper
+          {" "}
+          <code>change</code>
+          {" "}
+          event. This is solved by this component.
+        </p>
+        <PropertiesAPIBlock
+          propTypesBlock={"PROPTYPES_BLOCK(src/Select/Select.js)"}
+        />
+        <PropertiesAPIBlock
+          propTypesBlock={"PROPTYPES_BLOCK(src/Select/SelectOption.js)"}
+        />
+        <ComponentExampleWrapper>
+          <ComponentExample>
+            <div className="row row-flex">
+              <div className="column-6">
+                <Select
+                  name={"Select example"}
+                  className="dropdown-select"
+                  onChange={selectedItem => console.log("prop", selectedItem)}
+                  placeholder="Select your Option…"
+                >
+                  <SelectOption value="Foobar" label="Foobar Label">
+                    <strong>Foobar</strong>
+                    <p>Description</p>
+                  </SelectOption>
+                  <SelectOption value="baz" label="baz Label">
+                    <strong>baz</strong>
+                    <p>Description</p>
+                  </SelectOption>
+                </Select>
+              </div>
+            </div>
+          </ComponentExample>
+          <CodeBlock>
+            {`import { Select } from "reactjs-components";
+import React from "react";
+
+class SimpleSelectExample extends React.Component {
+  render() {
+    return (
+      <Select
+        name={"Select example"}
+        className="dropdown-select"
+        onChange={selectedItem => console.log("prop", selectedItem)}
+        placeholder="Select your Option…"
+      >
+        <SelectOption value="Foobar" label="Foobar Label">
+          <strong>Foobar</strong>
+          <p>Description</p>
+        </SelectOption>
+        <SelectOption value="baz" label="baz Label">
+          <strong>baz</strong>
+          <p>Description</p>
+        </SelectOption>
+      </Select>
+    );
+  }
+}`}
+          </CodeBlock>
+        </ComponentExampleWrapper>
+      </ComponentWrapper>
+    );
+  }
+}
+
+module.exports = SelectExample;

--- a/docs/src/index.js
+++ b/docs/src/index.js
@@ -8,6 +8,7 @@ import BindMixin from "../../src/Mixin/BindMixin";
 import ConfirmExample from "./Confirm";
 import DOMUtil from "../../src/Util/DOMUtil";
 import DropdownExample from "./Dropdown";
+import SelectExample from "./Select";
 import FormExample from "./Form";
 import ListExample from "./List";
 import ModalExample from "./Modal";
@@ -23,6 +24,12 @@ const navigationItems = [
     id: "dropdown",
     component: DropdownExample,
     passScrollContainer: true
+  },
+  {
+    label: "Select",
+    id: "select",
+    component: SelectExample,
+    passScrollContainer: false
   },
   {
     label: "Form",

--- a/main.js
+++ b/main.js
@@ -2,6 +2,8 @@ var Confirm = require("./lib/Confirm/Confirm");
 var Dropdown = require("./lib/Dropdown/Dropdown");
 var DropdownTrigger = require("./lib/Dropdown/DropdownTrigger").default;
 var DropdownListTrigger = require("./lib/Dropdown/DropdownListTrigger").default;
+var Select = require("./lib/Select/Select").default;
+var SelectOption = require("./lib/Select/SelectOption").default;
 var Form = require("./lib/Form/Form");
 var List = require("./lib/List/List");
 var Modal = require("./lib/Modal/Modal");
@@ -13,6 +15,8 @@ module.exports = {
   Dropdown: Dropdown,
   DropdownTrigger: DropdownTrigger,
   DropdownListTrigger: DropdownListTrigger,
+  Select: Select,
+  SelectOption: SelectOption,
   Form: Form,
   List: List,
   Modal: Modal,

--- a/package.json
+++ b/package.json
@@ -16,10 +16,7 @@
     "url": "https://github.com/mesosphere/reactjs-components"
   },
   "license": "Apache-2.0",
-  "files": [
-    "main.js",
-    "lib"
-  ],
+  "files": ["main.js", "lib"],
   "main": "main.js",
   "dependencies": {
     "classnames": "2.2.3",
@@ -85,10 +82,13 @@
   },
   "scripts": {
     "clean": "rm -rf dist docs/dist lib",
-    "dist": "npm run clean && NODE_ENV='production' ./node_modules/.bin/gulp docs:dist",
+    "dist":
+      "npm run clean && NODE_ENV='production' ./node_modules/.bin/gulp docs:dist",
     "predist-src": "rm -rf ./lib",
-    "dist-src": "cp -r ./src ./lib && find ./lib -name '__tests__' -type d -exec rm -r '{}' + && ./node_modules/.bin/babel lib --out-dir lib",
-    "livereload": "NODE_ENV='development' ./node_modules/.bin/gulp docs:livereload",
+    "dist-src":
+      "cp -r ./src ./lib && find ./lib -name '__tests__' -type d -exec rm -r '{}' + && ./node_modules/.bin/babel lib --out-dir lib",
+    "livereload":
+      "NODE_ENV='development' ./node_modules/.bin/gulp docs:livereload",
     "test": "NODE_PATH=node_modules jest --config=jest/config.json --no-cache",
     "release": "npm version -m 'Version %s'",
     "release:major": "npm run release -- major",
@@ -102,7 +102,9 @@
     "lint": "npm run stylelint && npm run eslint",
     "eslint": "eslint --quiet src/**/*.js docs/src/**/*.js",
     "stylelint": "stylelint src/**/*.less  docs/src/**/*.less",
-    "preversion": "npm run clean && npm test && npm run lint && npm run dist-src",
-    "postversion": "git push --tags && npm publish ./ --tag version-$npm_package_version && git push && echo \"Successfully released $npm_package_version\""
+    "preversion":
+      "npm run clean && npm test && npm run lint && npm run dist-src",
+    "postversion":
+      "git push --tags && npm publish ./ --tag version-$npm_package_version && git push && echo \"Successfully released $npm_package_version\""
   }
 }

--- a/src/Select/Select.js
+++ b/src/Select/Select.js
@@ -1,0 +1,100 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+import Dropdown from "../Dropdown/Dropdown";
+import DropdownListTrigger from "../Dropdown/DropdownListTrigger";
+
+class Select extends React.Component {
+  constructor() {
+    super(...arguments);
+
+    this.state = {
+      value: this.getInitialValue()
+    };
+  }
+
+  buildItemsArray() {
+    return React.Children.map(this.props.children, child => {
+      return {
+        html: child,
+        id: child.props.value,
+        selectedHtml: child.props.label,
+        selectable: !child.props.disabled
+      };
+    });
+  }
+
+  getInitialValue() {
+    const children = React.Children.toArray(this.props.children);
+    const selectedChild = children.find(child => child.props.selected === true);
+
+    if (selectedChild) {
+      return selectedChild.props.value;
+    }
+
+    // if placeholder is set, we can return null
+    if (this.props.placeholder !== "") {
+      return null;
+    }
+
+    // if not, we need to return a value. (legacy)
+    return children[0].props.value;
+  }
+
+  handleInputChange(event) {
+    this.props.onChange(event);
+  }
+
+  handleDropdownChange(selectedOption) {
+    const event = new Event("input", { bubbles: true });
+
+    this.setState({ value: selectedOption.id });
+
+    this.input.value = selectedOption.id;
+    this.input.dispatchEvent(event);
+  }
+
+  render() {
+    return (
+      <div className={this.props.className}>
+        <input
+          className="dropdown-select input-value"
+          name={this.props.name}
+          ref={input => (this.input = input)}
+          style={{
+            display: "none"
+          }}
+          value={this.state.value}
+          onChange={this.handleInputChange.bind(this)}
+        />
+        <Dropdown
+          items={this.buildItemsArray()}
+          initialID={this.state.value}
+          onItemSelection={this.handleDropdownChange.bind(this)}
+          buttonClassName={"button dropdown-toggle"}
+          dropdownMenuClassName={"dropdown-menu"}
+          dropdownMenuListClassName={"dropdown-menu-list"}
+          dropdownMenuListItemClassName={"dropdown-menu-list-item"}
+          wrapperClassName={"dropdown"}
+          trigger={<DropdownListTrigger placeholder={this.props.placeholder} />}
+        />
+      </div>
+    );
+  }
+}
+
+Select.defaultProps = {
+  className: "dropdown-select",
+  onChange() {},
+  name: null,
+  placeholder: ""
+};
+
+Select.propTypes = {
+  className: PropTypes.string,
+  onChange: PropTypes.func,
+  name: PropTypes.string,
+  placeholder: PropTypes.string
+};
+
+module.exports = Select;

--- a/src/Select/SelectOption.js
+++ b/src/Select/SelectOption.js
@@ -1,0 +1,24 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+class SelectOption extends React.Component {
+  render() {
+    return (
+      <div>{this.props.children || this.props.label || this.props.value}</div>
+    );
+  }
+}
+SelectOption.defaultProps = {
+  value: null,
+  label: null,
+  disabled: false,
+  selected: false
+};
+SelectOption.propTypes = {
+  value: PropTypes.string,
+  label: PropTypes.string,
+  disabled: PropTypes.bool,
+  selected: PropTypes.bool
+};
+
+module.exports = SelectOption;

--- a/src/Select/__tests__/Select-test.js
+++ b/src/Select/__tests__/Select-test.js
@@ -1,0 +1,88 @@
+jest.dontMock("../../Mixin/BindMixin");
+jest.dontMock("../../Util/Util");
+jest.dontMock("../../Util/DOMUtil");
+jest.dontMock("../Select");
+jest.dontMock("../SelectOption");
+
+/* eslint-disable no-unused-vars */
+var React = require("react");
+/* eslint-enable no-unused-vars */
+
+var TestUtils;
+if (React.version.match(/15.[0-5]/)) {
+  TestUtils = require("react-addons-test-utils");
+} else {
+  TestUtils = require("react-dom/test-utils");
+}
+
+var Select = require("../Select.js");
+var SelectOption = require("../SelectOption.js");
+
+describe("Select", function() {
+  beforeEach(function() {
+    this.callback = jasmine.createSpy();
+    this.select = TestUtils.renderIntoDocument(
+      <Select
+        className="select-class-1 select-class-2"
+        onChange={this.callback}
+        name="SelectName"
+      >
+        <SelectOption value="option-1" label="option-1-label">
+          default selected(false) & disabled(false)
+        </SelectOption>
+        <SelectOption
+          value="option-2"
+          label="option-2-label"
+          disabled={true}
+          selected={false}
+        >
+          disabled
+        </SelectOption>
+        <SelectOption
+          value="option-3"
+          label="option-3-label"
+          disabled={false}
+          selected={true}
+        >
+          selected
+        </SelectOption>
+        <SelectOption value="option-5" label="option-5-label">
+          <p>One HTML Child</p>
+        </SelectOption>
+        <SelectOption value="option-6" label="option-6-label">
+          <p>Multiple HTML Children</p>
+          <p>Multiple HTML Children</p>
+        </SelectOption>
+      </Select>
+    );
+  });
+
+  afterEach(function() {
+    Array.prototype.slice.call(document.body.children).forEach(function(node) {
+      document.body.removeChild(node);
+    });
+  });
+  describe("#Init", function() {
+    it("has correct classes", function() {
+      expect(this.select.props.className).toEqual(
+        "select-class-1 select-class-2"
+      );
+    });
+    it("has correct name", function() {
+      expect(this.select.props.name).toEqual("SelectName");
+    });
+    it("has correct change listener", function() {
+      expect(this.select.props.onChange).toBe(this.callback);
+    });
+    it("does not call change listener on init", function() {
+      expect(this.callback).not.toBeCalled();
+    });
+    it("has correct initial value", function() {
+      const input = TestUtils.findRenderedDOMComponentWithClass(
+        this.select,
+        "dropdown-select input-value"
+      );
+      expect(input.value).toEqual("option-3");
+    });
+  });
+});


### PR DESCRIPTION
**⚠️  ~~depends on #418~~** 

This component wraps the existing Dropdown, but also adds an input field which
enables us to emit proper onChange events.

Example Usage (can be used for testing):
```
outdated, see comment below
```
This exact example is from the `Create Service > Volumes > Local Volumes` Select, you can replace the existing one after linking the branch from `reactjs-components` and importing it.

Closes DCOS-19313