### PR TITLE
chore(react-gemini-scrollbar): re-add 2.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "cnvs": "1.1.9",
     "react": "^15.0.0 || ^16.0.0",
     "react-transition-group": "1.2.x",
-    "react-gemini-scrollbar": "2.3.x"
+    "react-gemini-scrollbar": "^2.1.5 || ^2.3.0"
   },
   "scripts": {
     "clean": "rm -rf dist docs/dist lib",


### PR DESCRIPTION
`react-gemini-scrollbar` 2.2.0 bumped `gemini-scrollbar` that introduced an `<object>` element to tract element resize events. 

This change confuses `cypress` and breaks our tests. 

Since we're not using `react@16` right now anyway, it's ok to allow using `react-gemini-scrollbar@2.1.5` until we fix everything and switch to `react@16`