### PR TITLE
DropdownTrigger: fix proptype type of function

### DIFF
--- a/src/Dropdown/DropdownListTrigger.js
+++ b/src/Dropdown/DropdownListTrigger.js
@@ -34,6 +34,6 @@ DropdownListTrigger.propTypes = {
   className: PropTypes.string,
   placeholder: PropTypes.string,
   selectedItem: PropTypes.object,
-  onTrigger: PropTypes.function,
+  onTrigger: PropTypes.func,
   disabled: PropTypes.bool
 };

--- a/src/Dropdown/DropdownTrigger.js
+++ b/src/Dropdown/DropdownTrigger.js
@@ -21,6 +21,6 @@ DropdownTrigger.defaultProps = {
 };
 
 DropdownTrigger.propTypes = {
-  onTrigger: PropTypes.function,
+  onTrigger: PropTypes.func,
   disabled: PropTypes.bool
 };


### PR DESCRIPTION
The proptypes package exports `.func` instead of `.function` to test if a prop is a function.