### PR TITLE
fix(VirtualList): prevents render failing on exception

### DIFF
--- a/src/VirtualList/VirtualList.js
+++ b/src/VirtualList/VirtualList.js
@@ -24,6 +24,14 @@ const METHODS_TO_BIND = [
   "visibleItems"
 ];
 
+const safeCall = f => {
+  try {
+    return f();
+  } catch (e) {
+    console.error(e);
+  }
+};
+
 class VirtualList extends React.Component {
   constructor() {
     super(...arguments);
@@ -139,11 +147,13 @@ class VirtualList extends React.Component {
 
   getItemsToRender(props, state) {
     return state.items.map(function(item, index) {
-      return props.renderItem(
-        item,
-        // Start from number of buffered items
-        state.bufferStart / props.itemHeight + index
-      );
+      return safeCall(() => {
+        return props.renderItem(
+          item,
+          // Start from number of buffered items
+          state.bufferStart / props.itemHeight + index
+        );
+      });
     });
   }
 
@@ -239,9 +249,9 @@ class VirtualList extends React.Component {
 
     return (
       <props.tagName ref="list" {...htmlAttributes}>
-        {props.renderBufferItem(topStyles)}
+        {safeCall(() => props.renderBufferItem(topStyles))}
         {this.getItemsToRender(props, state)}
-        {props.renderBufferItem(bottomStyles)}
+        {safeCall(() => props.renderBufferItem(bottomStyles))}
       </props.tagName>
     );
   }

--- a/src/VirtualList/__tests__/VirtualList-test.js
+++ b/src/VirtualList/__tests__/VirtualList-test.js
@@ -8,15 +8,22 @@ const React = require("react");
 const ReactDOM = require("react-dom");
 const VirtualList = require("../VirtualList");
 
+var TestUtils;
+if (React.version.match(/15.[0-5]/)) {
+  TestUtils = require("react-addons-test-utils");
+} else {
+  TestUtils = require("react-dom/test-utils");
+}
+
 describe("VirtualList", function() {
   beforeEach(function() {
     this.container = global.document.createElement("div");
     this.instance = ReactDOM.render(
       <VirtualList
-        items={[]}
+        items={[1]}
         itemHeight={10}
-        renderItem={function() {}}
-        renderBufferItem={function() {}}
+        renderItem={function(item) { return <span>item</span>;}}
+        renderBufferItem={function(item) { return <span>item</span>;}}
       />,
       this.container
     );
@@ -331,6 +338,17 @@ describe("VirtualList", function() {
         [undefined, 2],
         [undefined, 3]
       ]);
+    });
+  });
+
+  describe("with some content", function(){
+    it("renders something", function() {
+      var tableContents = TestUtils.scryRenderedDOMComponentsWithTag(
+        this.instance,
+        "span"
+      );
+
+      expect(tableContents.length).toBe(3);
     });
   });
 

--- a/src/VirtualList/__tests__/VirtualList-test.js
+++ b/src/VirtualList/__tests__/VirtualList-test.js
@@ -333,4 +333,80 @@ describe("VirtualList", function() {
       ]);
     });
   });
+
+  describe("with failing renderItem", function() {
+    beforeEach(function() {
+      this.container = global.document.createElement("div");
+      this.instance = ReactDOM.render(
+        <VirtualList
+          items={[<li>1</li>]}
+          itemHeight={10}
+          renderItem={function() {
+            throw Error("fail");
+          }}
+          renderBufferItem={function() {}}
+        />,
+        this.container
+      );
+    });
+
+    afterEach(function() {
+      ReactDOM.unmountComponentAtNode(this.container);
+    });
+
+    it("renders properly filling the viewport", function() {
+      var view = {
+        top: 0,
+        bottom: 1000
+      };
+
+      var list = {
+        top: view.top,
+        bottom: view.bottom
+      };
+
+      var box = this.instance.getBox(view, list);
+
+      expect(box.top).toBe(0);
+      expect(box.bottom).toBe(1000);
+    });
+  });
+
+  describe("with failing renderBufferItem", function() {
+    beforeEach(function() {
+      this.container = global.document.createElement("div");
+      this.instance = ReactDOM.render(
+        <VirtualList
+          items={[<li>1</li>]}
+          itemHeight={10}
+          renderItem={function() {}}
+          renderBufferItem={function() {
+            throw Error("fail");
+          }}
+        />,
+        this.container
+      );
+    });
+
+    afterEach(function() {
+      ReactDOM.unmountComponentAtNode(this.container);
+    });
+
+    it("renders properly filling the viewport", function() {
+      var view = {
+        top: 0,
+        bottom: 1000
+      };
+
+      var list = {
+        top: view.top,
+        bottom: view.bottom
+      };
+
+      var box = this.instance.getBox(view, list);
+
+      expect(box.top).toBe(0);
+      expect(box.bottom).toBe(1000);
+    });
+  });
 });


### PR DESCRIPTION
VirtuaList receives as props functions to render its
items when those functions throw, we send react into
havoc and it starts rendering infinite lists. This
fixes this problem by wrapping the functions on try/catch

CLOSES DCOS-21362

Also, trick to test, but you can:
- On your DC/OS UI repo, checkout branch `bug-reproduce-dcos-20507`, commit `b65b398a59c9ac4f784982e77deaddef0345aa50` go to the nodes page and try to filter for Unhealthy, and back. This will set your list into *infinite craziness ™* (from this reproduction PR https://github.com/dcos/dcos-ui/pull/2760)
- link reactjs-components, check out on this branch, and see that the craziness is gone