### PR TITLE
fix(Table): don't use virtual list for small tables

### DIFF
--- a/src/Table/__tests__/Table-test.js
+++ b/src/Table/__tests__/Table-test.js
@@ -101,8 +101,8 @@ describe("Table", function() {
         "tr"
       );
 
-      expect(tableRows[2].children[0].textContent).toEqual("Zach");
-      expect(tableRows[6].children[0].textContent).toEqual("Francis");
+      expect(tableRows[1].children[0].textContent).toEqual("Zach");
+      expect(tableRows[5].children[0].textContent).toEqual("Francis");
     });
 
     it("should sort the data ascending on initial mount", function() {
@@ -122,8 +122,8 @@ describe("Table", function() {
         "tr"
       );
 
-      expect(tableRows[2].children[0].textContent).toEqual("Francis");
-      expect(tableRows[6].children[0].textContent).toEqual("Zach");
+      expect(tableRows[1].children[0].textContent).toEqual("Francis");
+      expect(tableRows[5].children[0].textContent).toEqual("Zach");
     });
   });
 });


### PR DESCRIPTION
Only use VirtualList for tables with large data sets.

## Testing

To test in dcos-ui:
- Check out this branch and run `npm run preversion`
- Go to dcos-ui and replace `reactjs-components` version number in package.json with `"file:../path/to/reactjscomponents/repo"`
- Run on soak and look at components that use reactjs-components table (ie Jobs > Detail)

Jobs run history table comparison:
- Before: https://cl.ly/fc46a4c05463
- After: https://cl.ly/34a03ec1ff43

## Tradeoffs

1000 was chosen as a semi arbitrary cutoff for using VirtualList