### PR TITLE
DCOS-48704: Permissions builder exception

### DIFF
--- a/src/Util/Util.js
+++ b/src/Util/Util.js
@@ -458,7 +458,7 @@ function find(objects, predicate) {
     }
   });
 
-  return result;
+  return result || {};
 }
 
 var isArray = function(arg) {


### PR DESCRIPTION
Prevent the find function from returning undefined in order to fix a dcos-ui bug.

Closes https://jira.mesosphere.com/browse/DCOS-48704

## Testing
1. In dcos-ui in `dcos-ui/node_modules/reactjs-components/lib/Util/Util.js` in the find function change `return result;` to `return result || {};` on line 472.
2. Run `npm start` and open the localhost.
3. Open Organization > Users.
4. Create a new user and open it.
5. Open the permissions builder modal.
6. Click around and verify that the modal doesn't crash.
Here are some cases that broke it before:
- From `Services -> Marathon -> Operator > Leadership` to `Services -> Marathon -> Operator > Events`.
- From `Admin Router > Services > Metronome (Jobs)` to `Secrets Store`.
- From `Mesos > Master > Framework > Role` to `Mesos > Master > Framework > Service Account` and vice versa.
- From `Mesos > Master > Quota` to `Mesos > Master > Executor`.

## Trade-offs
None.

## Dependencies
After merging this, we will also have to update the reactjs-components version in `dcos-ui`.

## Screenshots
### Before
![Peek 2019-06-19 11-53](https://user-images.githubusercontent.com/40791275/59751275-e95e7500-9288-11e9-98e1-7aae9f7b6858.gif)
![Peek 2019-06-19 11-52](https://user-images.githubusercontent.com/40791275/59751283-ebc0cf00-9288-11e9-852f-6d0443934695.gif)

### After
![Peek 2019-06-19 11-56](https://user-images.githubusercontent.com/40791275/59751471-42c6a400-9289-11e9-9b37-aaa6edbdc2d1.gif)
![Peek 2019-06-19 11-55](https://user-images.githubusercontent.com/40791275/59751477-4528fe00-9289-11e9-9653-321b4ecdac43.gif)
